### PR TITLE
Add window_ms to CircuitBreakerConfig + From conversion

### DIFF
--- a/crates/rivers-runtime/src/datasource.rs
+++ b/crates/rivers-runtime/src/datasource.rs
@@ -118,6 +118,10 @@ pub struct CircuitBreakerConfig {
     #[serde(default = "default_failure_threshold")]
     pub failure_threshold: u32,
 
+    /// Rolling window in milliseconds for counting failures. Default: 60000 (60s).
+    #[serde(default = "default_window_ms")]
+    pub window_ms: u64,
+
     #[serde(default = "default_open_timeout")]
     pub open_timeout_ms: u64,
 
@@ -130,10 +134,15 @@ impl Default for CircuitBreakerConfig {
         Self {
             enabled: false,
             failure_threshold: default_failure_threshold(),
+            window_ms: default_window_ms(),
             open_timeout_ms: default_open_timeout(),
             half_open_max_trials: default_half_open_trials(),
         }
     }
+}
+
+fn default_window_ms() -> u64 {
+    60_000
 }
 
 fn default_failure_threshold() -> u32 {

--- a/crates/riversd/src/pool.rs
+++ b/crates/riversd/src/pool.rs
@@ -137,6 +137,19 @@ impl Default for CircuitBreakerConfig {
     }
 }
 
+/// Convert datasource config CB to pool CB config.
+impl From<&rivers_runtime::datasource::CircuitBreakerConfig> for CircuitBreakerConfig {
+    fn from(ds: &rivers_runtime::datasource::CircuitBreakerConfig) -> Self {
+        Self {
+            enabled: ds.enabled,
+            failure_threshold: ds.failure_threshold,
+            window_ms: ds.window_ms,
+            open_timeout_ms: ds.open_timeout_ms,
+            half_open_max_trials: ds.half_open_max_trials,
+        }
+    }
+}
+
 // ── CircuitBreaker ─────────────────────────────────────────────────
 
 /// Circuit breaker state.


### PR DESCRIPTION
## Summary
- Added `window_ms` to datasource `CircuitBreakerConfig` (default 60s rolling window)
- Added `From<&datasource::CircuitBreakerConfig>` for `pool::CircuitBreakerConfig`
- Both CB configs now have matching fields

## Test plan
- [ ] `circuit_breaker.window_ms = 30000` parses correctly
- [ ] From conversion maps all fields

Generated with [Claude Code](https://claude.com/claude-code)