### PR TITLE
Wire per-method CRUD queries via HTTP method parameter

### DIFF
--- a/crates/rivers-runtime/src/dataview_engine.rs
+++ b/crates/rivers-runtime/src/dataview_engine.rs
@@ -466,6 +466,7 @@ impl DataViewExecutor {
         &self,
         name: &str,
         params: HashMap<String, QueryValue>,
+        method: &str,
         trace_id: &str,
     ) -> Result<DataViewResponse, DataViewError> {
         let start = Instant::now();
@@ -478,8 +479,9 @@ impl DataViewExecutor {
                 name: name.to_string(),
             })?;
 
-        // 2. Parameter validation
+        // 2. Parameter validation (use HTTP method for per-method query/param resolution)
         let request = DataViewRequestBuilder::new(name)
+            .method(method)
             .params(params)
             .trace_id(trace_id)
             .build_for(config)?;

--- a/crates/riversd/src/engine_loader.rs
+++ b/crates/riversd/src/engine_loader.rs
@@ -358,7 +358,7 @@ extern "C" fn host_dataview_execute(
     match ctx.rt_handle.block_on(async {
         let guard = executor_lock.read().await;
         let executor = guard.as_ref().ok_or_else(|| "DataViewExecutor not initialized".to_string())?;
-        executor.execute(&name, params, &trace_id).await.map_err(|e| e.to_string())
+        executor.execute(&name, params, "GET", &trace_id).await.map_err(|e| e.to_string())
     }) {
         Ok(response) => {
             // Serialize DataViewResponse.query_result to JSON

--- a/crates/riversd/src/graphql.rs
+++ b/crates/riversd/src/graphql.rs
@@ -591,7 +591,7 @@ pub fn build_schema_with_executor(
 
                     let trace_id = format!("gql-{}", uuid::Uuid::new_v4());
                     let response = exec
-                        .execute(&dataview, params, &trace_id)
+                        .execute(&dataview, params, "GET", &trace_id)
                         .await
                         .map_err(|e| async_graphql::Error::new(e.to_string()))?;
 

--- a/crates/riversd/src/polling.rs
+++ b/crates/riversd/src/polling.rs
@@ -451,7 +451,7 @@ impl PollDataViewExecutor for DataViewPollExecutor {
             .collect();
 
         let response = exec
-            .execute(dataview_name, query_params, "poll")
+            .execute(dataview_name, query_params, "GET", "poll")
             .await
             .map_err(|e| PollError::DataViewError(e.to_string()))?;
 

--- a/crates/riversd/src/process_pool/v8_engine.rs
+++ b/crates/riversd/src/process_pool/v8_engine.rs
@@ -959,7 +959,7 @@ fn ctx_dataview_callback(
 
         match get_rt_handle() {
             Ok(rt) => {
-                match rt.block_on(exec.execute(&name, query_params, &trace_id)) {
+                match rt.block_on(exec.execute(&name, query_params, "GET", &trace_id)) {
                     Ok(response) => {
                         // Convert QueryResult rows to JSON
                         let json = serde_json::json!({

--- a/crates/riversd/src/view_engine.rs
+++ b/crates/riversd/src/view_engine.rs
@@ -498,7 +498,7 @@ pub async fn execute_rest_view(
                             .collect();
 
                     let response = exec
-                        .execute(dataview, query_params, &ctx.trace_id)
+                        .execute(dataview, query_params, &ctx.request.method, &ctx.trace_id)
                         .await
                         .map_err(|e| ViewError::Handler(format!("dataview '{}': {}", dataview, e)))?;
 


### PR DESCRIPTION
## Summary
Added `method` parameter to `DataViewExecutor::execute()` enabling per-method query/schema/parameter resolution.

## Fields wired (12)
`get_query`, `post_query`, `put_query`, `delete_query`, `get_schema`, `post_schema`, `put_schema`, `delete_schema`, `get_parameters`, `post_parameters`, `put_parameters`, `delete_parameters`

## Call sites updated
- view_engine.rs — passes actual HTTP method from request
- graphql.rs — "GET" for queries
- engine_loader.rs, v8_engine.rs — "GET" for host callbacks
- polling.rs — "GET" for poll ticks

## Test plan
- [ ] DataView with `post_query = "INSERT..."` + POST request → uses INSERT query
- [ ] DataView with only `query` (legacy) → works for all methods

Generated with [Claude Code](https://claude.com/claude-code)