### PR TITLE
Add POST /admin/shutdown endpoint

### DIFF
--- a/crates/riversd/src/admin_handlers.rs
+++ b/crates/riversd/src/admin_handlers.rs
@@ -309,3 +309,49 @@ pub async fn admin_log_reset_handler(State(ctx): State<AppContext>) -> Response 
         None => log_controller_unavailable(),
     }
 }
+
+// ── Shutdown Endpoint ────────────────────────────────────────────
+
+/// POST /admin/shutdown
+///
+/// Body: `{"mode": "graceful"}` or `{"mode": "immediate"}`
+///
+/// Graceful: marks server as draining, in-flight requests complete, then exits.
+/// Immediate: exits the process after response flushes.
+pub async fn admin_shutdown_handler(
+    State(ctx): State<AppContext>,
+    request: Request,
+) -> impl IntoResponse {
+    let body = parse_json_body(request, 1024).await;
+    let mode = body
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("graceful");
+
+    match mode {
+        "immediate" => {
+            tracing::warn!("admin API: immediate shutdown requested");
+            let response = Json(serde_json::json!({
+                "status": "shutting_down",
+                "mode": "immediate"
+            }));
+            // Spawn exit after short delay to allow response to flush
+            tokio::spawn(async {
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                std::process::exit(0);
+            });
+            response.into_response()
+        }
+        _ => {
+            tracing::info!("admin API: graceful shutdown requested");
+            ctx.shutdown.mark_draining();
+            if let Some(ref tx) = ctx.shutdown_tx {
+                let _ = tx.send(true);
+            }
+            Json(serde_json::json!({
+                "status": "shutting_down",
+                "mode": "graceful"
+            })).into_response()
+        }
+    }
+}

--- a/crates/riversd/src/main.rs
+++ b/crates/riversd/src/main.rs
@@ -194,7 +194,8 @@ async fn async_main(
     }
 
     // Serve
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let shutdown_tx = std::sync::Arc::new(shutdown_tx);
 
     if args.no_ssl {
         let port = args
@@ -207,7 +208,7 @@ async fn async_main(
             "riversd starting"
         );
         if let Err(e) =
-            riversd::server::run_server_no_ssl(config, port, shutdown_rx).await
+            riversd::server::run_server_no_ssl(config, port, shutdown_rx, Some(shutdown_tx.clone())).await
         {
             tracing::error!(error = %e, "server failed");
             std::process::exit(1);
@@ -238,6 +239,7 @@ async fn async_main(
                 listener,
                 shutdown_rx,
                 Some(log_controller),
+                Some(shutdown_tx),
             )
             .await
         {

--- a/crates/riversd/src/server.rs
+++ b/crates/riversd/src/server.rs
@@ -153,6 +153,8 @@ pub struct AppContext {
     pub graphql_schema: Arc<tokio::sync::RwLock<Option<async_graphql::dynamic::Schema>>>,
     /// DriverFactory — shared with host callbacks for cdylib engine access.
     pub driver_factory: Option<Arc<rivers_runtime::rivers_core::DriverFactory>>,
+    /// Shutdown sender — triggers graceful shutdown when sent `true`.
+    pub shutdown_tx: Option<Arc<tokio::sync::watch::Sender<bool>>>,
 }
 
 impl AppContext {
@@ -183,6 +185,7 @@ impl AppContext {
             ws_manager: Arc::new(WebSocketRouteManager::new()),
             graphql_schema: Arc::new(tokio::sync::RwLock::new(None)),
             driver_factory: None,
+            shutdown_tx: None,
         }
     }
 }
@@ -327,6 +330,8 @@ pub fn build_admin_router(ctx: AppContext) -> Router {
         .route("/admin/log/levels", get(admin_log_levels_handler))
         .route("/admin/log/set", axum::routing::post(admin_log_set_handler))
         .route("/admin/log/reset", axum::routing::post(admin_log_reset_handler))
+        // Shutdown endpoint
+        .route("/admin/shutdown", axum::routing::post(admin_shutdown_handler))
         .with_state(ctx);
 
     // Admin middleware: admin_auth → timeout → security_headers → trace_id → body_limit
@@ -1324,6 +1329,7 @@ use crate::admin_handlers::{
     admin_deploy_approve_handler, admin_deploy_reject_handler,
     admin_deploy_promote_handler, admin_deployments_handler,
     admin_log_levels_handler, admin_log_set_handler, admin_log_reset_handler,
+    admin_shutdown_handler,
 };
 
 
@@ -1460,6 +1466,7 @@ fn path_to_admin_permission(path: &str) -> Option<crate::admin::AdminPermission>
         "/admin/deploy/promote" => Some(AdminPermission::DeployPromote),
         "/admin/deployments" => Some(AdminPermission::DeployRead),
         p if p.starts_with("/admin/log") => Some(AdminPermission::Admin),
+        "/admin/shutdown" => Some(AdminPermission::Admin),
         _ => None,
     }
 }
@@ -1704,6 +1711,7 @@ pub async fn run_server_no_ssl(
     config: ServerConfig,
     port: u16,
     shutdown_rx: watch::Receiver<bool>,
+    shutdown_tx: Option<Arc<tokio::sync::watch::Sender<bool>>>,
 ) -> Result<(), ServerError> {
     tracing::warn!("--no-ssl: TLS is DISABLED for this session — do not use in production");
 
@@ -1724,6 +1732,7 @@ pub async fn run_server_no_ssl(
     // Build context same as TLS path
     let shutdown = Arc::new(ShutdownCoordinator::new());
     let mut ctx = AppContext::new(config.clone(), shutdown.clone());
+    ctx.shutdown_tx = shutdown_tx;
 
     // Build RBAC config once at startup (AN11.4)
     if config.base.admin_api.enabled {
@@ -1751,7 +1760,7 @@ pub async fn run_server_with_listener_with_control(
     listener: TcpListener,
     shutdown_rx: watch::Receiver<bool>,
 ) -> Result<(), ServerError> {
-    run_server_with_listener_and_log(config, listener, shutdown_rx, None).await
+    run_server_with_listener_and_log(config, listener, shutdown_rx, None, None).await
 }
 
 /// Primary server entry point with optional log controller.
@@ -1763,6 +1772,7 @@ pub async fn run_server_with_listener_and_log(
     listener: TcpListener,
     shutdown_rx: watch::Receiver<bool>,
     log_controller: Option<Arc<LogController>>,
+    shutdown_tx: Option<Arc<tokio::sync::watch::Sender<bool>>>,
 ) -> Result<(), ServerError> {
     // Step 2: Config validation — TLS is mandatory (no_ssl=false)
     validate_server_tls(&config, false)
@@ -1772,6 +1782,7 @@ pub async fn run_server_with_listener_and_log(
     let shutdown = Arc::new(ShutdownCoordinator::new());
     let mut ctx = AppContext::new(config.clone(), shutdown.clone());
     ctx.log_controller = log_controller;
+    ctx.shutdown_tx = shutdown_tx;
 
     // Build RBAC config once at startup instead of per-request (AN11.4)
     if config.base.admin_api.enabled {


### PR DESCRIPTION
## Summary
Implements `/admin/shutdown` so `riversctl stop` and `riversctl graceful` work via admin API instead of signal fallback.

- `{"mode": "graceful"}` — drain + shutdown
- `{"mode": "immediate"}` — exit after response flush

## Test plan
- [ ] `riversctl graceful` → server drains and exits
- [ ] `riversctl stop` → server exits immediately
- [ ] Without admin API running → falls back to SIGTERM/SIGKILL

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)