### PR TITLE
perf(ci): speed up builds with sccache and CI profile

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,11 +3,15 @@ name: Build Linux
 on:
   push:
     branches: [main]
+    paths: ['crates/**', 'Cargo.*', '.github/workflows/build-linux.yml']
   pull_request:
     branches: [main]
+    paths: ['crates/**', 'Cargo.*', '.github/workflows/build-linux.yml']
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-x86_64:
@@ -18,18 +22,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: linux-x86_64-cargo-
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Build
-        run: cargo build --release -p riversd -p riversctl -p rivers-lockbox -p riverpackage
+        run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
 
       - name: Run tests
         run: cargo test --workspace --lib
@@ -49,17 +46,10 @@ jobs:
           curl -sSfL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | tar xzf - -C "$HOME/.cargo/bin"
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-aarch64-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: linux-aarch64-cargo-
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Build (cross-compile)
         run: |
-          cross build --release --target aarch64-unknown-linux-gnu \
+          cross build --profile ci --target aarch64-unknown-linux-gnu \
             -p riversd -p riversctl -p rivers-lockbox -p riverpackage

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,11 +3,15 @@ name: Build macOS
 on:
   push:
     branches: [main]
+    paths: ['crates/**', 'Cargo.*', '.github/workflows/build-macos.yml']
   pull_request:
     branches: [main]
+    paths: ['crates/**', 'Cargo.*', '.github/workflows/build-macos.yml']
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-arm64:
@@ -18,18 +22,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: macos-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: macos-arm64-cargo-
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Build
-        run: cargo build --release -p riversd -p riversctl -p rivers-lockbox -p riverpackage
+        run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
 
       - name: Run tests
         run: cargo test --workspace --lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   # ── Build matrix ──────────────────────────────────────────────────
@@ -41,15 +43,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: release-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: release-${{ matrix.target }}-cargo-
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Install cross
         if: matrix.cross
@@ -123,6 +118,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Build dynamic libraries
         shell: bash
         run: |
@@ -187,11 +184,9 @@ jobs:
           ARTIFACT_NAME: ${{ matrix.artifact }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          # Extract dynamic libs (x86_64 only — aarch64 dynamic build not yet available)
           tar xzf rivers-dynamic-libs.tar.gz 2>/dev/null || true
           tar xzf rivers-*.tar.gz
 
-          # ── rivers (base) ──
           BASE="rivers_${VERSION}_${DEB_ARCH}"
           mkdir -p "${BASE}/DEBIAN" "${BASE}/usr/bin" "${BASE}/etc/rivers" \
                    "${BASE}/lib/systemd/system" "${BASE}/var/lib/rivers" \
@@ -221,7 +216,6 @@ jobs:
           cp packaging/systemd/riversd.service "${BASE}/lib/systemd/system/"
           dpkg-deb --build --root-owner-group "$BASE"
 
-          # ── rivers-lib ──
           LIB="rivers-lib_${VERSION}_${DEB_ARCH}"
           mkdir -p "${LIB}/DEBIAN" "${LIB}/usr/lib/rivers"
           cat > "${LIB}/DEBIAN/control" <<EOF
@@ -237,7 +231,6 @@ jobs:
           cp dynamic-libs/*.so "${LIB}/usr/lib/rivers/" 2>/dev/null || true
           dpkg-deb --build --root-owner-group "$LIB"
 
-          # ── rivers-plugins ──
           PLUG="rivers-plugins_${VERSION}_${DEB_ARCH}"
           mkdir -p "${PLUG}/DEBIAN" "${PLUG}/usr/lib/rivers/plugins"
           cat > "${PLUG}/DEBIAN/control" <<EOF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,10 @@ jsonschema = "0.28"
 lto = "thin"
 codegen-units = 1
 strip = "symbols"
+
+# Fast CI builds — skip LTO, parallel codegen
+[profile.ci]
+inherits = "release"
+lto = false
+codegen-units = 16
+strip = "symbols"


### PR DESCRIPTION
## Summary
- Add `[profile.ci]` (lto=false, codegen-units=16) for fast CI/PR builds — tagged releases keep full `--release` with LTO
- Replace manual cargo cache with `sccache` via `mozilla-actions/sccache-action` — caches compiled object files across runs
- Add path filters (`crates/**`, `Cargo.*`) so docs-only or config-only changes skip builds entirely

## Expected impact
| Change | Estimated savings |
|--------|-------------------|
| sccache (warm cache) | 60-80% of rebuild time |
| codegen-units=16 | ~30% of codegen phase |
| lto=false for CI | ~40% of link time |
| Path filters | Skip entire builds for non-code changes |

## Test plan
- [x] `cargo build --profile ci` compiles locally
- [ ] First CI run populates sccache (cold — normal speed)
- [ ] Subsequent CI runs hit sccache (warm — should be significantly faster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)