### PR TITLE
fix(ci): sccache graceful fallback on cache outage

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -11,7 +11,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-x86_64:
@@ -23,10 +22,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
+        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib
@@ -47,9 +50,13 @@ jobs:
             | tar xzf - -C "$HOME/.cargo/bin"
 
       - name: Setup sccache
+        id: sccache-arm
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
 
       - name: Build (cross-compile)
         run: |
           cross build --profile ci --target aarch64-unknown-linux-gnu \
             -p riversd -p riversctl -p rivers-lockbox -p riverpackage
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache-arm.outcome == 'success' && 'sccache' || '' }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,7 +11,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-arm64:
@@ -23,10 +22,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
+        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   # ── Build matrix ──────────────────────────────────────────────────
@@ -44,7 +43,9 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup sccache
+        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
 
       - name: Install cross
         if: matrix.cross
@@ -58,6 +59,7 @@ jobs:
         env:
           BUILD_TARGET: ${{ matrix.target }}
           USE_CROSS: ${{ matrix.cross }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
         run: |
           if [ "$USE_CROSS" = "true" ]; then
             cross build --release --target "$BUILD_TARGET" \
@@ -119,9 +121,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Setup sccache
+        id: sccache-dyn
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
       - name: Build dynamic libraries
         shell: bash
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache-dyn.outcome == 'success' && 'sccache' || '' }}
         run: |
           sed -i 's/crate-type = \["rlib"\]/crate-type = ["dylib"]/' crates/rivers-runtime/Cargo.toml
           export CARGO_PROFILE_RELEASE_LTO=off


### PR DESCRIPTION
## Summary
- Fix build failures when GitHub Actions cache service is unavailable
- Move `RUSTC_WRAPPER` from global env to per-build-step env, set conditionally on sccache setup success
- Add `continue-on-error: true` to all sccache setup steps

## Root cause
PR #39 set `RUSTC_WRAPPER: "sccache"` globally. When the Actions cache service returned HTTP 400, sccache failed to start, and cargo couldn't invoke rustc at all.

## Fix
sccache setup now uses `continue-on-error: true` with a step ID. Build steps check the outcome:
```yaml
RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
```
If sccache fails, `RUSTC_WRAPPER` is empty and cargo compiles directly — slower but working.

## Test plan
- [x] When sccache works: builds use cache (fast)
- [x] When sccache fails: builds proceed without cache (slower but no failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)