### PR TITLE
fix(ci): health-check sccache before use

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,17 +22,29 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
+
+      - name: Check sccache health
+        id: sccache
+        run: |
+          if sccache --show-stats >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::sccache unavailable, building without cache"
+          fi
         continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
         env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
   build-aarch64:
     runs-on: ubuntu-latest
@@ -50,8 +62,18 @@ jobs:
             | tar xzf - -C "$HOME/.cargo/bin"
 
       - name: Setup sccache
-        id: sccache-arm
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
+
+      - name: Check sccache health
+        id: sccache
+        run: |
+          if sccache --show-stats >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::sccache unavailable, building without cache"
+          fi
         continue-on-error: true
 
       - name: Build (cross-compile)
@@ -59,4 +81,4 @@ jobs:
           cross build --profile ci --target aarch64-unknown-linux-gnu \
             -p riversd -p riversctl -p rivers-lockbox -p riverpackage
         env:
-          RUSTC_WRAPPER: ${{ steps.sccache-arm.outcome == 'success' && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,14 +22,26 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
+
+      - name: Check sccache health
+        id: sccache
+        run: |
+          if sccache --show-stats >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::sccache unavailable, building without cache"
+          fi
         continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
         env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib
+        env:
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,19 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Setup sccache
-        id: sccache
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
+
+      - name: Check sccache health
+        id: sccache
+        shell: bash
+        run: |
+          if sccache --show-stats >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::sccache unavailable, building without cache"
+          fi
         continue-on-error: true
 
       - name: Install cross
@@ -59,7 +70,7 @@ jobs:
         env:
           BUILD_TARGET: ${{ matrix.target }}
           USE_CROSS: ${{ matrix.cross }}
-          RUSTC_WRAPPER: ${{ steps.sccache.outcome == 'success' && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
         run: |
           if [ "$USE_CROSS" = "true" ]; then
             cross build --release --target "$BUILD_TARGET" \
@@ -121,13 +132,22 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Setup sccache
-        id: sccache-dyn
         uses: mozilla-actions/sccache-action@v0.0.6
+        continue-on-error: true
+      - name: Check sccache health
+        id: sccache-dyn
+        run: |
+          if sccache --show-stats >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::sccache unavailable, building without cache"
+          fi
         continue-on-error: true
       - name: Build dynamic libraries
         shell: bash
         env:
-          RUSTC_WRAPPER: ${{ steps.sccache-dyn.outcome == 'success' && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ steps.sccache-dyn.outputs.available == 'true' && 'sccache' || '' }}
         run: |
           sed -i 's/crate-type = \["rlib"\]/crate-type = ["dylib"]/' crates/rivers-runtime/Cargo.toml
           export CARGO_PROFILE_RELEASE_LTO=off


### PR DESCRIPTION
## Summary
Fixes build failures from PR #39/#40 where sccache-action installs successfully but the cache backend is unreachable.

## Root cause
`sccache-action` always succeeds (it just installs the binary). The `continue-on-error` + `outcome == 'success'` check from PR #40 still evaluates to true, so `RUSTC_WRAPPER=sccache` gets set. sccache then fails at compile time when it can't reach the cache backend.

## Fix
Add an explicit health check step that runs `sccache --show-stats` to verify the cache backend is reachable. `RUSTC_WRAPPER` is only set if `outputs.available == 'true'`:

```yaml
- name: Check sccache health
  id: sccache
  run: |
    if sccache --show-stats >/dev/null 2>&1; then
      echo "available=true" >> "$GITHUB_OUTPUT"
    else
      echo "available=false" >> "$GITHUB_OUTPUT"
    fi
  continue-on-error: true

- name: Build
  env:
    RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
```

## Test plan
- Cache service up: health check passes → sccache used → fast build
- Cache service down: health check fails → `RUSTC_WRAPPER` empty → direct compilation → slower but working

🤖 Generated with [Claude Code](https://claude.com/claude-code)