### PR TITLE
fix(ci): unset RUSTC_WRAPPER when sccache backend is down

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,26 +25,18 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
         continue-on-error: true
 
-      - name: Check sccache health
-        id: sccache
+      - name: Disable sccache if unhealthy
         run: |
-          if sccache --show-stats >/dev/null 2>&1; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::sccache unavailable, building without cache"
+          if ! sccache --show-stats >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "::warning::sccache cache backend unavailable — building without cache"
           fi
-        continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
   build-aarch64:
     runs-on: ubuntu-latest
@@ -65,20 +57,14 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
         continue-on-error: true
 
-      - name: Check sccache health
-        id: sccache
+      - name: Disable sccache if unhealthy
         run: |
-          if sccache --show-stats >/dev/null 2>&1; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::sccache unavailable, building without cache"
+          if ! sccache --show-stats >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "::warning::sccache cache backend unavailable — building without cache"
           fi
-        continue-on-error: true
 
       - name: Build (cross-compile)
         run: |
           cross build --profile ci --target aarch64-unknown-linux-gnu \
             -p riversd -p riversctl -p rivers-lockbox -p riverpackage
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,23 +25,15 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
         continue-on-error: true
 
-      - name: Check sccache health
-        id: sccache
+      - name: Disable sccache if unhealthy
         run: |
-          if sccache --show-stats >/dev/null 2>&1; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::sccache unavailable, building without cache"
+          if ! sccache --show-stats >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "::warning::sccache cache backend unavailable — building without cache"
           fi
-        continue-on-error: true
 
       - name: Build
         run: cargo build --profile ci -p riversd -p riversctl -p rivers-lockbox -p riverpackage
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
 
       - name: Run tests
         run: cargo test --workspace --lib
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,17 +46,13 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.6
         continue-on-error: true
 
-      - name: Check sccache health
-        id: sccache
+      - name: Disable sccache if unhealthy
         shell: bash
         run: |
-          if sccache --show-stats >/dev/null 2>&1; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::sccache unavailable, building without cache"
+          if ! sccache --show-stats >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "::warning::sccache cache backend unavailable — building without cache"
           fi
-        continue-on-error: true
 
       - name: Install cross
         if: matrix.cross
@@ -70,7 +66,6 @@ jobs:
         env:
           BUILD_TARGET: ${{ matrix.target }}
           USE_CROSS: ${{ matrix.cross }}
-          RUSTC_WRAPPER: ${{ steps.sccache.outputs.available == 'true' && 'sccache' || '' }}
         run: |
           if [ "$USE_CROSS" = "true" ]; then
             cross build --release --target "$BUILD_TARGET" \
@@ -134,20 +129,14 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.6
         continue-on-error: true
-      - name: Check sccache health
-        id: sccache-dyn
+      - name: Disable sccache if unhealthy
         run: |
-          if sccache --show-stats >/dev/null 2>&1; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::sccache unavailable, building without cache"
+          if ! sccache --show-stats >/dev/null 2>&1; then
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "::warning::sccache cache backend unavailable — building without cache"
           fi
-        continue-on-error: true
       - name: Build dynamic libraries
         shell: bash
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache-dyn.outputs.available == 'true' && 'sccache' || '' }}
         run: |
           sed -i 's/crate-type = \["rlib"\]/crate-type = ["dylib"]/' crates/rivers-runtime/Cargo.toml
           export CARGO_PROFILE_RELEASE_LTO=off


### PR DESCRIPTION
## Summary
Third fix attempt for sccache failures. Previous approaches (step-level env override, step outputs) didn't work because sccache-action writes `RUSTC_WRAPPER=sccache` to `GITHUB_ENV` and step-level env overrides aren't reliably taking effect.

## Fix
Write `RUSTC_WRAPPER=` directly to `GITHUB_ENV` when the health check fails, which overwrites the value the sccache-action set:

```yaml
- name: Disable sccache if unhealthy
  run: |
    if ! sccache --show-stats >/dev/null 2>&1; then
      echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
    fi
```

This is the same mechanism sccache-action uses to SET the variable — we use it to UNSET it.

## Test plan
- Cache up: sccache works normally, `RUSTC_WRAPPER` stays as `sccache`
- Cache down: health check fails, `RUSTC_WRAPPER` overwritten to empty, cargo compiles directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)