### PR TITLE
feat: cross-compilation and Docker container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+target/
+!target/x86_64-unknown-linux-gnu/ci/riversd
+!target/x86_64-unknown-linux-gnu/ci/riversctl
+.git
+.claude
+.worktrees
+node_modules
+release
+todo
+scratch
+data
+sec
+test
+*.log

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[target.x86_64-unknown-linux-gnu]
+image = "rivers-cross-x86_64:latest"
+
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture arm64",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+## Rivers runtime container
+## Build: docker build --platform linux/amd64 -t rivers:latest -f docker/Dockerfile .
+## Run:   docker run -p 8080:8080 -v ./my-bundle:/app/bundle rivers:latest
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    groupadd -r rivers && useradd -r -g rivers -d /var/lib/rivers -s /sbin/nologin rivers && \
+    mkdir -p /etc/rivers /var/lib/rivers /var/log/rivers && \
+    chown -R rivers:rivers /var/lib/rivers /var/log/rivers
+
+COPY target/x86_64-unknown-linux-gnu/ci/riversd /usr/bin/riversd
+COPY target/x86_64-unknown-linux-gnu/ci/riversctl /usr/bin/riversctl
+COPY packaging/config/riversd.toml /etc/rivers/riversd.toml
+
+USER rivers
+WORKDIR /var/lib/rivers
+
+EXPOSE 8080
+
+ENTRYPOINT ["riversd", "--config", "/etc/rivers/riversd.toml"]

--- a/docker/Dockerfile.x86_64-linux
+++ b/docker/Dockerfile.x86_64-linux
@@ -1,0 +1,12 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y gcc-12 g++-12 cmake && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add `cross` support for building Linux x86_64 binaries from macOS (Apple Silicon)
- Custom cross build image with gcc-12 to fix `aws-lc-sys` compiler compatibility
- Minimal Docker runtime container (debian-slim, **55 MB**)
- V8 optional — build without it for smaller binaries that cross-compile cleanly

## Build workflow
```bash
# Cross-compile Linux binary from macOS
cross build --profile ci --target x86_64-unknown-linux-gnu \
  -p riversd --no-default-features --features static-plugins,static-builtin-drivers

# Build Docker image
docker build --platform linux/amd64 -t rivers:0.52.5 -f docker/Dockerfile .

# Run
docker run -p 8080:8080 -v ./my-bundle:/app/bundle rivers:0.52.5
```

## Binary sizes
| Build | Size | V8 |
|-------|------|-----|
| macOS release (full) | 60 MB | Yes |
| macOS CI (no V8) | 38 MB | No |
| Linux x86_64 cross (no V8) | 43 MB | No |
| Docker image | 55 MB | No |

## Test plan
- [x] `cross build` produces valid Linux ELF binary
- [x] Docker image builds successfully
- [x] `docker run rivers:0.52.5 --version` returns `riversd 0.52.5 (x86_64)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)