### PR TITLE
release: v0.52.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.52.5"
+version = "0.52.6"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/cargo-deploy/src/main.rs
+++ b/crates/cargo-deploy/src/main.rs
@@ -45,7 +45,7 @@ const PLUGIN_LIB_NAMES: &[&str] = &[
 ];
 
 /// Binary names to deploy.
-const BINARIES: &[&str] = &["riversd", "riversctl", "rivers-lockbox", "riverpackage"];
+const BINARIES: &[&str] = &["riversd", "riversctl", "rivers-lockbox", "rivers-keystore", "riverpackage"];
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -147,6 +147,7 @@ fn deploy_dynamic(workspace_root: &Path, target_dir: &Path, deploy_path: &Path, 
         "-p", "riversd",
         "-p", "riversctl",
         "-p", "rivers-lockbox",
+        "-p", "rivers-keystore",
         "-p", "riverpackage",
     ]);
 
@@ -222,6 +223,7 @@ fn deploy_static(_workspace_root: &Path, target_dir: &Path, deploy_path: &Path, 
         "-p", "riversd",
         "-p", "riversctl",
         "-p", "rivers-lockbox",
+        "-p", "rivers-keystore",
         "-p", "riverpackage",
     ]);
 


### PR DESCRIPTION
## Summary
- Add `rivers-keystore` to `cargo deploy` binary list (both static and dynamic modes)
- Bump workspace version 0.52.5 → 0.52.6

## What's new since v0.52.5
- `cargo deploy` subcommand (static + dynamic modes)
- Cross-compilation support (macOS → Linux via `cross`)
- Docker container support (55 MB image)
- Dropped `notify` and `rustls-pemfile` dependencies
- AI agentic docs updated to v0.52.5
- CI speedup with sccache + CI profile
- Gitignore cleanup (54K lines of non-distribution files removed)
- V8 engine `ctx.ws` injection for WebSocket hooks
- Bundle validation fixes (kafka, rabbitmq, nats, ldap, chat-app)

## Test plan
- [x] `cargo check -p cargo-deploy` compiles
- [ ] Tag `v0.52.6` after merge to trigger release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)