### PR TITLE
fix(security): 5 quick-win security hardening fixes

### DIFF
--- a/crates/rivers-driver-sdk/src/http_driver.rs
+++ b/crates/rivers-driver-sdk/src/http_driver.rs
@@ -167,9 +167,10 @@ pub enum HttpProtocol {
 }
 
 /// TLS configuration for HTTP connections.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TlsConfig {
-    /// Whether to verify the upstream's TLS certificate.
+    /// Whether to verify the upstream's TLS certificate (default: true).
+    #[serde(default = "default_tls_verify")]
     pub verify: bool,
     /// Optional CA certificate path for custom CAs.
     pub ca_cert: Option<String>,
@@ -177,6 +178,21 @@ pub struct TlsConfig {
     pub client_cert: Option<String>,
     /// Optional client key path for mTLS.
     pub client_key: Option<String>,
+}
+
+impl Default for TlsConfig {
+    fn default() -> Self {
+        Self {
+            verify: true,
+            ca_cert: None,
+            client_cert: None,
+            client_key: None,
+        }
+    }
+}
+
+fn default_tls_verify() -> bool {
+    true
 }
 
 // ── Auth ────────────────────────────────────────────────────────────

--- a/crates/riversd/src/cors.rs
+++ b/crates/riversd/src/cors.rs
@@ -124,6 +124,10 @@ impl CorsHeaders {
         if self.is_preflight {
             headers.insert("access-control-max-age", HeaderValue::from_static("86400"));
         }
+        // Vary: Origin required when origin is dynamically reflected (not *)
+        if self.allow_origin != "*" {
+            headers.insert("vary", HeaderValue::from_static("Origin"));
+        }
     }
 }
 

--- a/crates/riversd/src/csrf.rs
+++ b/crates/riversd/src/csrf.rs
@@ -144,7 +144,7 @@ impl CsrfManager {
 /// Per spec §9.1: NOT HttpOnly (readable by JavaScript), SameSite=Lax, Path=/.
 pub fn build_csrf_cookie(token: &str, config: &CsrfConfig) -> String {
     format!(
-        "{}={}; SameSite=Lax; Path=/",
+        "{}={}; SameSite=Lax; Path=/; Secure",
         config.cookie_name, token
     )
 }

--- a/crates/riversd/src/middleware.rs
+++ b/crates/riversd/src/middleware.rs
@@ -145,6 +145,10 @@ pub async fn security_headers_middleware(request: Request<Body>, next: Next) -> 
         "referrer-policy",
         HeaderValue::from_static("strict-origin-when-cross-origin"),
     );
+    headers.insert(
+        "strict-transport-security",
+        HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
     // CSP is the operator's responsibility — not injected by default.
 
     response

--- a/crates/riversd/src/server/admin_auth.rs
+++ b/crates/riversd/src/server/admin_auth.rs
@@ -135,19 +135,19 @@ pub(super) async fn admin_auth_middleware(
 
 /// Map an admin API path to the required `AdminPermission`.
 ///
-/// Returns `None` for unknown paths (middleware will allow through).
+/// Unknown paths default to `Admin` (deny by default — highest privilege required).
 fn path_to_admin_permission(path: &str) -> Option<crate::admin::AdminPermission> {
     use crate::admin::AdminPermission;
-    match path {
-        "/admin/status" | "/admin/drivers" | "/admin/datasources" => Some(AdminPermission::StatusRead),
-        "/admin/deploy" | "/admin/deploy/test" => Some(AdminPermission::DeployWrite),
-        "/admin/deploy/approve" | "/admin/deploy/reject" => Some(AdminPermission::DeployApprove),
-        "/admin/deploy/promote" => Some(AdminPermission::DeployPromote),
-        "/admin/deployments" => Some(AdminPermission::DeployRead),
-        p if p.starts_with("/admin/log") => Some(AdminPermission::Admin),
-        "/admin/shutdown" => Some(AdminPermission::Admin),
-        _ => None,
-    }
+    Some(match path {
+        "/admin/status" | "/admin/drivers" | "/admin/datasources" => AdminPermission::StatusRead,
+        "/admin/deploy" | "/admin/deploy/test" => AdminPermission::DeployWrite,
+        "/admin/deploy/approve" | "/admin/deploy/reject" => AdminPermission::DeployApprove,
+        "/admin/deploy/promote" => AdminPermission::DeployPromote,
+        "/admin/deployments" => AdminPermission::DeployRead,
+        p if p.starts_with("/admin/log") => AdminPermission::Admin,
+        "/admin/shutdown" => AdminPermission::Admin,
+        _ => AdminPermission::Admin, // deny by default
+    })
 }
 
 /// Fallback for when `admin_auth_config` is not initialized (e.g. tests).


### PR DESCRIPTION
## Summary

Five security fixes from the audit — all one-liners or small changes.

| # | Severity | Fix | Change |
|---|----------|-----|--------|
| 5 | Medium | CSRF cookie `Secure` flag | Prevents MITM interception over HTTP |
| 7 | **High** | TLS verify default `true` | Outbound connections validate certs by default |
| 10 | Medium | Admin RBAC deny-by-default | Unknown paths require Admin permission |
| 12 | Low | CORS `Vary: Origin` header | Prevents CDN cache poisoning |
| 16 | Low | HSTS header | `max-age=31536000; includeSubDomains` |

## Breaking change

**Finding #7**: Outbound HTTP datasource connections now verify TLS certificates by default. Operators connecting to self-signed upstreams must explicitly set `verify = false` in their datasource TLS config. This is the correct security posture per OWASP/CIS.

## Test plan
- [x] `cargo check -p riversd -p rivers-driver-sdk` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)