### PR TITLE
release: v0.52.7 — security hardening

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.52.6"
+version = "0.52.7"
 license = "MIT"
 
 [workspace.dependencies]


### PR DESCRIPTION
## v0.52.7 — Security Hardening Release

14 of 17 audit findings resolved across 4 merged PRs (#49, #50, #51, #52).

### Breaking change
- Outbound HTTP datasource TLS verification now enabled by default. Set `verify = false` explicitly for self-signed upstreams.

### Tag after merge
```bash
git tag v0.52.7 && git push origin v0.52.7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)