### PR TITLE
feat: Sprint 2 hardening — path containment, file limits, pool guard

### DIFF
--- a/crates/rivers-runtime/src/bundle.rs
+++ b/crates/rivers-runtime/src/bundle.rs
@@ -107,6 +107,38 @@ fn default_index() -> String {
     "index.html".to_string()
 }
 
+// ── Path Containment ──────────────────────────────────────────────
+
+/// Validate that a module path stays within the app's libraries directory.
+///
+/// Canonicalizes the path and checks it starts with `app_dir/libraries/`.
+/// Prevents path traversal attacks via `../../` in module paths from TOML config.
+///
+/// Returns `Ok(canonical_path)` if contained, `Err(reason)` if it escapes.
+pub fn validate_module_path(
+    app_dir: &std::path::Path,
+    module: &str,
+) -> Result<std::path::PathBuf, String> {
+    let libraries_dir = app_dir.join("libraries");
+    let full_path = libraries_dir.join(module);
+
+    // Canonicalize resolves symlinks and ../ components
+    let canonical = full_path.canonicalize().map_err(|e| {
+        format!("module path '{}' cannot be resolved: {e}", full_path.display())
+    })?;
+
+    let canonical_libraries = libraries_dir.canonicalize().unwrap_or(libraries_dir);
+
+    if !canonical.starts_with(&canonical_libraries) {
+        return Err(format!(
+            "module path '{}' escapes app libraries directory",
+            module
+        ));
+    }
+
+    Ok(canonical)
+}
+
 // ── Resources config ────────────────────────────────────────────────
 
 /// `resources.toml` — declares datasources and service dependencies.

--- a/crates/riversd/src/bundle_loader/load.rs
+++ b/crates/riversd/src/bundle_loader/load.rs
@@ -514,16 +514,11 @@ async fn dispatch_init_handler(
         .as_deref()
         .unwrap_or(&app.manifest.app_name);
 
-    let module_path = app.app_dir
-        .join("libraries")
-        .join(&init_config.module);
-
-    if !module_path.exists() {
-        return Err(format!(
-            "init handler module not found: {}",
-            module_path.display()
-        ));
-    }
+    // Validate module path containment — prevent path traversal
+    let module_path = rivers_runtime::bundle::validate_module_path(
+        &app.app_dir,
+        &init_config.module,
+    ).map_err(|e| format!("init handler: {e}"))?;
 
     let entrypoint = Entrypoint {
         module: module_path.to_string_lossy().to_string(),

--- a/crates/riversd/src/pool.rs
+++ b/crates/riversd/src/pool.rs
@@ -56,6 +56,53 @@ pub enum PoolError {
     Config(String),
 }
 
+// ── PoolGuard (RAII connection release) ────────────────────────────
+
+/// RAII guard for pool connections.
+///
+/// Automatically decrements `active_count` when dropped, preventing
+/// connection leaks on panics or early returns. The connection is
+/// dropped (not returned to idle) — callers who want to reuse should
+/// call `pool.release()` explicitly and `std::mem::forget` the guard.
+pub struct PoolGuard {
+    active_count: Arc<AtomicU64>,
+    /// Held connection — dropped when guard is dropped.
+    _conn: Option<Box<dyn Connection>>,
+}
+
+impl PoolGuard {
+    /// Create a guard for a checked-out connection.
+    pub fn new(conn: Box<dyn Connection>, active_count: Arc<AtomicU64>) -> Self {
+        Self {
+            active_count,
+            _conn: Some(conn),
+        }
+    }
+
+    /// Get a mutable reference to the underlying connection.
+    pub fn conn_mut(&mut self) -> &mut Box<dyn Connection> {
+        self._conn.as_mut().expect("connection already taken")
+    }
+
+    /// Take the connection out of the guard (for explicit release to pool).
+    /// Caller is responsible for calling pool.release() and active_count management.
+    pub fn take(mut self) -> Box<dyn Connection> {
+        // Prevent Drop from decrementing active_count
+        let conn = self._conn.take().expect("connection already taken");
+        std::mem::forget(self);
+        conn
+    }
+}
+
+impl Drop for PoolGuard {
+    fn drop(&mut self) {
+        if self._conn.is_some() {
+            // Connection dropped without explicit release — decrement active count
+            self.active_count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
 // ── PoolConfig ─────────────────────────────────────────────────────
 
 /// Per-datasource pool configuration.

--- a/crates/riversd/src/static_files.rs
+++ b/crates/riversd/src/static_files.rs
@@ -161,6 +161,15 @@ pub async fn serve_static_file(
         None => return crate::error_response::not_found("not found").into_axum_response(),
     };
 
+    // Check file size before reading into memory (default: 50 MiB)
+    const MAX_STATIC_FILE_SIZE: u64 = 50 * 1024 * 1024;
+    if let Ok(meta) = tokio::fs::metadata(&file_path).await {
+        if meta.len() > MAX_STATIC_FILE_SIZE {
+            return crate::error_response::ErrorResponse::new(413, "file too large")
+                .into_axum_response();
+        }
+    }
+
     // Read file
     let content = match tokio::fs::read(&file_path).await {
         Ok(bytes) => bytes,


### PR DESCRIPTION
## Summary

Sprint 2 — three hardening items from the security audit.

### S2.1 — Static file size limit
- Check file metadata before reading into memory
- Files exceeding 50 MiB return 413 Payload Too Large
- Prevents OOM from serving large bundled files

### S2.2 — Connection pool RAII guard
- `PoolGuard` auto-decrements `active_count` on Drop
- Prevents connection leaks when handlers panic
- `take()` method for explicit release back to pool
- `conn_mut()` for accessing the underlying connection

### S2.3 — Module path containment
- `validate_module_path()` canonicalizes paths and checks containment
- Prevents `../../etc/passwd` style traversal in TOML module paths
- Applied to init handler dispatch
- Reusable for view handler module resolution

## Test plan
- [x] `cargo check` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)