### PR TITLE
fix: ctx.ddl() init handler — HOST_CONTEXT + whitelist resolution (v0.53.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5295,7 +5295,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "hex",
  "rivers-core-config",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "clap",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "rivers-lockbox-engine",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "chrono",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "hex",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-nats",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "neo4rs",
@@ -5631,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "age",
  "async-trait",
@@ -5662,7 +5662,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "hex",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-trait",
  "redis",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.53.3"
+version = "0.53.5"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.53.4"
+version = "0.53.5"
 license = "MIT"
 
 [workspace.dependencies]

--- a/bugs/bugreport_2026-04-07_6.md
+++ b/bugs/bugreport_2026-04-07_6.md
@@ -1,0 +1,53 @@
+# Bug Report — 2026-04-07 (#6)
+
+## Summary
+Init handler `ctx.ddl()` fails silently — HOST_CONTEXT not set at init time, and DDL whitelist uses wrong app_id format.
+
+## Symptoms
+- Init handler JS logs `ddl_test_init_start` but `ctx.ddl()` fails with `HOST_CONTEXT not set` (no table created)
+- After HOST_CONTEXT fix, DDL rejected by whitelist (Gate 3) — entry_point name `"service"` used instead of manifest UUID `"deadbeef-..."`
+- SQLite DB file is 4096 bytes (empty header, no tables)
+- View handlers return 500 with `no such table: items`
+
+## Environment
+Rivers 0.53.4, macOS, SQLite datasource, V8 engine (cdylib), debug build.
+
+## Root Cause
+Three independent issues:
+
+### 1. HOST_CONTEXT not set before init handlers
+`set_host_context()` was called in `lifecycle.rs` AFTER `load_and_wire_bundle()`, but init handlers run INSIDE `load_and_wire_bundle()`. So `HOST_CONTEXT` OnceLock was empty when `host_ddl_execute` checked it.
+
+**File:** `crates/riversd/src/server/lifecycle.rs` (lines 241-249, both entry points)
+
+### 2. DDL whitelist checked datasource name, not database path
+`host_ddl_execute` passed the JS datasource name (`"test_db"`) to `is_ddl_permitted()`, but the whitelist format is `{database}@{appId}` where database is the file path (`ddl-test-service/data/test.db`). Gate 3 check needed to resolve ConnectionParams first.
+
+**File:** `crates/riversd/src/engine_loader/host_callbacks.rs` (line 690)
+
+### 3. DDL whitelist used entry_point name instead of manifest UUID
+ProcessPool sets `TASK_APP_ID` to the entry_point name (e.g., `"service"`), but the whitelist expects the manifest app_id UUID. No mapping between the two existed.
+
+**File:** `crates/riversd/src/engine_loader/host_callbacks.rs` (line 685)
+
+## Fix Applied
+
+### Fix 1: Move HOST_CONTEXT wiring before init handlers
+Added `set_host_context()`, `set_ddl_whitelist()`, and `set_app_id_map()` calls inside `load_and_wire_bundle()` right after DataViewExecutor and DriverFactory are created — before the Phase 1.5 init handler loop. The OnceLock ensures subsequent calls in `lifecycle.rs` are harmless no-ops.
+
+**File:** `crates/riversd/src/bundle_loader/load.rs`
+
+### Fix 2: Resolve database path before whitelist check
+Moved Gate 3 whitelist check into the async block AFTER resolving ConnectionParams from the DataViewExecutor. Now uses `ds_params.database` (the actual database path) instead of the JS-level datasource name.
+
+**File:** `crates/riversd/src/engine_loader/host_callbacks.rs`
+
+### Fix 3: Map entry_point → manifest UUID
+Added `APP_ID_MAP` OnceLock in `host_context.rs` that maps entry_point names to manifest UUIDs. Populated during bundle loading. `host_ddl_execute` resolves the entry_point to UUID before the whitelist check.
+
+**Files:** `crates/riversd/src/engine_loader/host_context.rs`, `crates/riversd/src/engine_loader/mod.rs`, `crates/riversd/src/bundle_loader/load.rs`
+
+## Occurrence Log
+| Date | Context | Notes |
+|------|---------|-------|
+| 2026-04-07 | IPAM team ddl-test-bundle repro | 3 root causes found and fixed |

--- a/crates/riversd/src/bundle_loader/load.rs
+++ b/crates/riversd/src/bundle_loader/load.rs
@@ -364,6 +364,36 @@ pub async fn load_and_wire_bundle(
     *ctx.dataview_executor.write().await = Some(executor.clone());
     ctx.driver_factory = Some(factory.clone());
 
+    // ── Wire HOST_CONTEXT before init handlers ──────────────────────
+    //
+    // Init handlers need HOST_CONTEXT for ctx.ddl() host callbacks.
+    // OnceLock ensures this is safe to call early — subsequent calls
+    // in lifecycle.rs are harmless no-ops.
+    crate::engine_loader::set_host_context(
+        ctx.dataview_executor.clone(),
+        ctx.storage_engine.clone(),
+        ctx.driver_factory.clone(),
+    );
+
+    // Wire DDL whitelist before init handlers so Gate 3 is active
+    let ddl_warnings = rivers_runtime::rivers_core_config::config::security::validate_ddl_whitelist(
+        &config.security.ddl_whitelist,
+    );
+    for w in &ddl_warnings {
+        tracing::warn!(target: "rivers.security", "{}", w);
+    }
+    crate::engine_loader::set_ddl_whitelist(config.security.ddl_whitelist.clone());
+
+    // Build entry_point → manifest app_id (UUID) map for DDL whitelist resolution
+    let mut app_id_map = std::collections::HashMap::new();
+    for app in &bundle.apps {
+        let entry_point = app.manifest.entry_point.as_deref()
+            .unwrap_or(&app.manifest.app_name)
+            .to_string();
+        app_id_map.insert(entry_point, app.manifest.app_id.clone());
+    }
+    crate::engine_loader::set_app_id_map(app_id_map);
+
     // ── Phase 1.5: Run application init handlers (DDL security spec) ──
     for app in &bundle.apps {
         if let Some(ref init_config) = app.manifest.init {

--- a/crates/riversd/src/engine_loader/host_callbacks.rs
+++ b/crates/riversd/src/engine_loader/host_callbacks.rs
@@ -682,42 +682,17 @@ pub(super) extern "C" fn host_ddl_execute(
             return -3;
         }
     };
-    let app_id = input["app_id"].as_str().unwrap_or("unknown").to_string();
+    let entry_point_id = input["app_id"].as_str().unwrap_or("unknown").to_string();
 
-    // Gate 3: Check DDL whitelist
-    if let Some(whitelist) = super::host_context::DDL_WHITELIST.get() {
-        if !whitelist.is_empty() {
-            if !rivers_runtime::rivers_core_config::config::security::is_ddl_permitted(
-                &datasource,
-                &app_id,
-                whitelist,
-            ) {
-                tracing::warn!(
-                    datasource = %datasource,
-                    app_id = %app_id,
-                    "DDL rejected by whitelist (Gate 3)"
-                );
-                // Log rejection to per-app log
-                if let Some(router) = rivers_runtime::rivers_core::app_log_router::global_router() {
-                    let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-                    let stmt_preview: String = statement.chars().take(80).collect();
-                    let line = format!(
-                        r#"{{"timestamp":"{ts}","level":"warn","app":"{app_id}","event":"DdlRejected","datasource":"{datasource}","statement":"{stmt_preview}","reason":"whitelist_gate3"}}"#
-                    );
-                    router.write(&app_id, &line);
-                }
-                let err_val = serde_json::json!({"error": format!(
-                    "DDL not permitted for datasource '{}' in app '{}'",
-                    datasource, app_id
-                )});
-                write_output(out_ptr, out_len, &err_val);
-                return -4;
-            }
-        }
-    }
+    // Resolve entry_point name to manifest UUID for whitelist check.
+    // The ProcessPool uses entry_point as app_id, but the whitelist
+    // format is `{database}@{appId}` with the manifest UUID.
+    let app_id = super::host_context::APP_ID_MAP.get()
+        .and_then(|map| map.get(&entry_point_id).cloned())
+        .unwrap_or_else(|| entry_point_id.clone());
 
     // Resolve connection params — try namespaced first (entry_point:datasource),
-    // then bare name
+    // then bare name. Gate 3 whitelist check uses the resolved database name.
     let executor_lock = ctx.dataview_executor.clone();
 
     // Clone for per-app logging after the async block (originals move into spawn)
@@ -727,6 +702,7 @@ pub(super) extern "C" fn host_ddl_execute(
 
     let (ds_tx, ds_rx) = std::sync::mpsc::channel();
     let factory = Arc::clone(factory);
+    let whitelist = super::host_context::DDL_WHITELIST.get().cloned();
     ctx.rt_handle.spawn(async move {
         let result = async {
             // Get datasource params from executor
@@ -750,6 +726,39 @@ pub(super) extern "C" fn host_ddl_execute(
 
                 (params, driver)
             };
+
+            // Gate 3: Check DDL whitelist using the resolved database name
+            // (not the JS-level datasource name). Whitelist format: "database@appId"
+            if let Some(ref whitelist) = whitelist {
+                if !whitelist.is_empty() {
+                    let database = &ds_params.database;
+                    if !rivers_runtime::rivers_core_config::config::security::is_ddl_permitted(
+                        database,
+                        &app_id,
+                        whitelist,
+                    ) {
+                        tracing::warn!(
+                            datasource = %datasource,
+                            database = %database,
+                            app_id = %app_id,
+                            "DDL rejected by whitelist (Gate 3)"
+                        );
+                        // Log rejection to per-app log
+                        if let Some(router) = rivers_runtime::rivers_core::app_log_router::global_router() {
+                            let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+                            let stmt_preview: String = statement.chars().take(80).collect();
+                            let line = format!(
+                                r#"{{"timestamp":"{ts}","level":"warn","app":"{app_id}","event":"DdlRejected","datasource":"{datasource}","database":"{database}","statement":"{stmt_preview}","reason":"whitelist_gate3"}}"#
+                            );
+                            router.write(&app_id, &line);
+                        }
+                        return Err(format!(
+                            "DDL not permitted for database '{}' (datasource '{}') in app '{}'",
+                            database, datasource, app_id
+                        ));
+                    }
+                }
+            }
 
             // Connect and execute DDL
             let mut conn = factory.connect(&driver_name, &ds_params).await

--- a/crates/riversd/src/engine_loader/host_context.rs
+++ b/crates/riversd/src/engine_loader/host_context.rs
@@ -28,6 +28,11 @@ pub(super) static HOST_KEYSTORE: OnceLock<Arc<rivers_keystore_engine::AppKeystor
 /// Set once during server startup from `config.security.ddl_whitelist`.
 pub(super) static DDL_WHITELIST: OnceLock<Vec<String>> = OnceLock::new();
 
+/// Maps entry_point names to manifest app_id UUIDs.
+/// Used by DDL whitelist check — the ProcessPool uses entry_point as app_id,
+/// but the whitelist format is `{database}@{appId}` with the manifest UUID.
+pub(super) static APP_ID_MAP: OnceLock<std::collections::HashMap<String, String>> = OnceLock::new();
+
 /// Wire host subsystem references so callbacks can reach DataViewExecutor,
 /// StorageEngine, DriverFactory, and HTTP client. Called once during server
 /// startup after all subsystems are initialized.
@@ -55,6 +60,14 @@ pub fn set_host_keystore(keystore: Arc<rivers_keystore_engine::AppKeystore>) {
 /// Called once during server startup alongside `set_host_context`.
 pub fn set_ddl_whitelist(whitelist: Vec<String>) {
     let _ = DDL_WHITELIST.set(whitelist);
+}
+
+/// Set the entry_point → manifest app_id (UUID) mapping.
+/// Called once during bundle loading so DDL whitelist checks can
+/// resolve the ProcessPool's entry_point-based app_id to the UUID
+/// used in whitelist entries.
+pub fn set_app_id_map(map: std::collections::HashMap<String, String>) {
+    let _ = APP_ID_MAP.set(map);
 }
 
 // ── Host Callback Implementations ───────────────────────────────

--- a/crates/riversd/src/engine_loader/mod.rs
+++ b/crates/riversd/src/engine_loader/mod.rs
@@ -13,4 +13,4 @@ mod host_callbacks;
 pub use loaded_engine::LoadedEngine;
 pub use registry::{get_engine, is_engine_available, execute_on_engine, loaded_engines};
 pub use loader::{EngineLoadResult, load_engines};
-pub use host_context::{set_host_context, set_host_keystore, set_ddl_whitelist, build_host_callbacks};
+pub use host_context::{set_host_context, set_host_keystore, set_ddl_whitelist, set_app_id_map, build_host_callbacks};

--- a/crates/riversd/src/server/lifecycle.rs
+++ b/crates/riversd/src/server/lifecycle.rs
@@ -241,20 +241,13 @@ pub async fn run_server_no_ssl(
     crate::bundle_loader::load_and_wire_bundle(&mut ctx, &config, shutdown_rx.clone()).await?;
     crate::task_enrichment::sync_from_app_context(&ctx);
 
-    // Wire host callbacks for cdylib engines
+    // Wire host callbacks for cdylib engines (no-op if already set
+    // during bundle load — OnceLock ensures idempotent)
     crate::engine_loader::set_host_context(
         ctx.dataview_executor.clone(),
         ctx.storage_engine.clone(),
         ctx.driver_factory.clone(),
     );
-
-    // Wire DDL whitelist for host callback gating
-    let ddl_warnings = rivers_runtime::rivers_core_config::config::security::validate_ddl_whitelist(
-        &config.security.ddl_whitelist,
-    );
-    for w in &ddl_warnings {
-        tracing::warn!(target: "rivers.security", "{}", w);
-    }
     crate::engine_loader::set_ddl_whitelist(config.security.ddl_whitelist.clone());
 
     // Wire shared keystore resolver for static engines
@@ -415,20 +408,13 @@ pub async fn run_server_with_listener_and_log(
     crate::bundle_loader::load_and_wire_bundle(&mut ctx, &config, shutdown_rx.clone()).await?;
     crate::task_enrichment::sync_from_app_context(&ctx);
 
-    // Wire host callbacks for cdylib engines — needs DataViewExecutor, StorageEngine, DriverFactory
+    // Wire host callbacks for cdylib engines (no-op if already set
+    // during bundle load — OnceLock ensures idempotent)
     crate::engine_loader::set_host_context(
         ctx.dataview_executor.clone(),
         ctx.storage_engine.clone(),
         ctx.driver_factory.clone(),
     );
-
-    // Wire DDL whitelist for host callback gating
-    let ddl_warnings = rivers_runtime::rivers_core_config::config::security::validate_ddl_whitelist(
-        &config.security.ddl_whitelist,
-    );
-    for w in &ddl_warnings {
-        tracing::warn!(target: "rivers.security", "{}", w);
-    }
     crate::engine_loader::set_ddl_whitelist(config.security.ddl_whitelist.clone());
 
     // Wire shared keystore resolver for static engines (V8/WASM) — fallback when

--- a/docs/bugs/rivers-053-ddl-init-handler-not-implemented.md
+++ b/docs/bugs/rivers-053-ddl-init-handler-not-implemented.md
@@ -3,7 +3,9 @@
 **Severity:** Blocker — any app relying on init handler DDL (the only permitted DDL path in 0.53.0) cannot create tables  
 **Rivers version:** 0.53.0 (source at `dist/rivers-0.53.0/`)  
 **Date filed:** 2026-04-07  
-**Status:** Fixed (0.53.5)  
+**Date fixed:** 2026-04-07  
+**Fixed in:** 0.53.5  
+**Status:** Fixed  
 **Reporter:** IPAM team  
 
 ---
@@ -57,16 +59,16 @@ Even if a host callback existed, there's no code path that calls `ddl_execute()`
 
 ## What works vs what doesn't
 
-| Component | Status |
-|-----------|--------|
-| `Connection::execute()` — Gate 1 DDL guard | Working — correctly rejects DDL |
-| `Connection::ddl_execute()` — SQLite impl | Working — code is correct, tests pass (`sqlite.rs:712-853`) |
-| `[init]` manifest parsing | Working — init config parsed, handler dispatched |
-| Init handler JS dispatch via ProcessPool | Working — JS executes, logs emitted |
-| `[security].ddl_whitelist` parsing | Untested — `_ddl_whitelist` param is unused |
-| `ctx.ddl()` JS → host callback → `ddl_execute()` | **NOT IMPLEMENTED** |
-| `ctx.admin()` JS → host callback | **NOT IMPLEMENTED** |
-| `ctx.query()` JS → host callback | **NOT IMPLEMENTED** |
+| Component | Status (0.53.0) | Status (0.53.5) |
+|-----------|-----------------|-----------------|
+| `Connection::execute()` — Gate 1 DDL guard | Working | Working |
+| `Connection::ddl_execute()` — SQLite impl | Working | Working |
+| `[init]` manifest parsing | Working | Working |
+| Init handler JS dispatch via ProcessPool | Working | Working |
+| `[security].ddl_whitelist` parsing | Untested | **Working** |
+| `ctx.ddl()` JS → host callback → `ddl_execute()` | **NOT IMPLEMENTED** | **Working** |
+| `ctx.admin()` JS → host callback | **NOT IMPLEMENTED** | Not yet implemented |
+| `ctx.query()` JS → host callback | **NOT IMPLEMENTED** | Not yet implemented |
 
 ---
 
@@ -138,8 +140,67 @@ Previously `null` was accepted for optional string parameters. We've fixed this 
 
 ## Impact
 
-Any application on 0.53.0 that needs schema initialization at startup is blocked. The old pattern (DDL via view handlers) is now forbidden by Gate 1, and the new pattern (DDL via init handler) is not yet functional. **There is no working DDL path in 0.53.0.**
+Any application on 0.53.0–0.53.4 that needs schema initialization at startup is blocked. The old pattern (DDL via view handlers) is now forbidden by Gate 1, and the new pattern (DDL via init handler) was not yet functional. **There was no working DDL path in 0.53.0–0.53.4.**
 
 ## Workaround
 
-None within Rivers. The only option is to create tables externally via `sqlite3` CLI before starting riversd, bypassing the init handler entirely.
+Upgrade to 0.53.5. No workaround needed — `ctx.ddl()` is fully functional.
+
+Previous workaround (0.53.0–0.53.4): create tables externally via `sqlite3` CLI before starting riversd, bypassing the init handler entirely.
+
+---
+
+## Resolution (0.53.5)
+
+Fixed across versions 0.53.3–0.53.5. The full `ctx.ddl()` path required fixes in three layers:
+
+### Version timeline
+
+| Version | What was done |
+|---------|---------------|
+| 0.53.0 | Gate 1 blocks DDL on `execute()`. `ctx.ddl()` not implemented (no-op) |
+| 0.53.3 | `host_ddl_execute` Rust callback implemented, but not in HostCallbacks ABI struct |
+| 0.53.4 | HostCallbacks ABI wired, `ctx.ddl()` reaches Rust, but HOST_CONTEXT not set at init time |
+| 0.53.5 | **Full fix** — 3 bugs resolved (see below) |
+
+### Fix 1: HOST_CONTEXT initialization order
+
+`set_host_context()` was called in `lifecycle.rs` **after** `load_and_wire_bundle()`, but init handlers run **inside** `load_and_wire_bundle()` (Phase 1.5). Moved `set_host_context()`, `set_ddl_whitelist()`, and `set_app_id_map()` into `load_and_wire_bundle()` right after DataViewExecutor and DriverFactory are created — before the init handler dispatch loop. The `OnceLock` ensures subsequent calls in `lifecycle.rs` are harmless no-ops.
+
+**File:** `crates/riversd/src/bundle_loader/load.rs`
+
+### Fix 2: DDL whitelist checked datasource name instead of database path
+
+The whitelist format is `{database}@{appId}`, but `host_ddl_execute` was passing the JS-level datasource name (e.g. `"test_db"`) to `is_ddl_permitted()`. The resolved `ConnectionParams.database` (e.g. `"ddl-test-service/data/test.db"`) is the correct value. Moved the Gate 3 whitelist check into the async block **after** resolving ConnectionParams from the DataViewExecutor.
+
+**File:** `crates/riversd/src/engine_loader/host_callbacks.rs`
+
+### Fix 3: Whitelist used entry_point name instead of manifest UUID
+
+The ProcessPool sets `TASK_APP_ID` to the entry_point name (e.g. `"service"`), but the whitelist expects the manifest `appId` UUID (e.g. `"deadbeef-0000-0000-0000-000000000001"`). Added an `APP_ID_MAP` OnceLock that maps entry_point names to manifest UUIDs, populated during bundle loading. `host_ddl_execute` resolves the entry_point to UUID before the whitelist check.
+
+**Files:** `crates/riversd/src/engine_loader/host_context.rs`, `crates/riversd/src/engine_loader/mod.rs`, `crates/riversd/src/bundle_loader/load.rs`
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `crates/riversd/src/bundle_loader/load.rs` | Wire HOST_CONTEXT, DDL_WHITELIST, APP_ID_MAP before Phase 1.5 |
+| `crates/riversd/src/engine_loader/host_callbacks.rs` | Resolve database path + UUID before whitelist check |
+| `crates/riversd/src/engine_loader/host_context.rs` | Add APP_ID_MAP OnceLock + setter |
+| `crates/riversd/src/engine_loader/mod.rs` | Export `set_app_id_map` |
+| `crates/riversd/src/server/lifecycle.rs` | Simplify (no-op after bundle load wiring) |
+
+### Verified with
+
+IPAM team's `ddl-test-bundle` (`dist/ddl-test-bundle.tar.gz`):
+- Init handler runs `ctx.ddl("test_db", "CREATE TABLE IF NOT EXISTS items ...")`
+- Gate 3 whitelist passes (`ddl-test-service/data/test.db@deadbeef-...`)
+- SQLite table created on disk
+- POST `/api/items` inserts rows via `ctx.dataview("insert_item", ...)`
+- GET `/api/items` returns rows via `ctx.dataview("list_items", ...)`
+
+### Remaining work
+
+- `ctx.admin()` — not yet implemented
+- `ctx.query()` — not yet implemented

--- a/docs/bugs/rivers-053-ddl-init-handler-not-implemented.md
+++ b/docs/bugs/rivers-053-ddl-init-handler-not-implemented.md
@@ -1,0 +1,145 @@
+# Bug: Init handler `ctx.ddl()` is not implemented — DDL silently no-ops
+
+**Severity:** Blocker — any app relying on init handler DDL (the only permitted DDL path in 0.53.0) cannot create tables  
+**Rivers version:** 0.53.0 (source at `dist/rivers-0.53.0/`)  
+**Date filed:** 2026-04-07  
+**Status:** Fixed (0.53.5)  
+**Reporter:** IPAM team  
+
+---
+
+## Summary
+
+The DDL security spec (Gate 1/2/3) correctly blocks DDL from view handlers via `execute()`. The init handler dispatches correctly and runs JavaScript. But `ctx.ddl()` in the init handler JS context is **not wired to any host callback** — calls resolve silently without executing any SQL. Tables are never created, and the init handler reports success.
+
+---
+
+## Root Cause — 3 missing pieces
+
+### 1. `dispatch_init_handler()` doesn't use the DataViewExecutor or whitelist
+
+**File:** `crates/riversd/src/bundle_loader/load.rs`, lines 542-548
+
+```rust
+async fn dispatch_init_handler(
+    pool: &ProcessPoolManager,
+    app: &rivers_runtime::LoadedApp,
+    init_config: &InitHandlerConfig,
+    _executor: &Arc<DataViewExecutor>,    // ← UNUSED (underscore prefix)
+    _ddl_whitelist: &[String],            // ← UNUSED (underscore prefix)
+    timeout_s: u64,
+) -> Result<(), String> {
+```
+
+The executor and whitelist are passed in from the caller (line 384) but never used. The init handler's TaskContext has no database dispatch capability.
+
+### 2. No `ctx.ddl()` host callback in V8 engine
+
+**File:** `crates/rivers-engine-v8/` — no `host_ddl_execute` or equivalent exists
+
+The DDL security spec (§8.1) defines the JS API:
+
+```typescript
+interface InitContext {
+    ddl(datasource: string, statement: string): Promise<QueryResult>;
+    admin(datasource: string, operation: string, params?: Record<string, any>): Promise<QueryResult>;
+    query(datasource: string, statement: string, params?: Record<string, any>): Promise<QueryResult>;
+}
+```
+
+None of these are implemented as V8 host callbacks. When JS calls `await ctx.ddl(...)`, it resolves to `undefined` without throwing — so the init handler completes "successfully."
+
+### 3. No path from host callback → `Connection::ddl_execute()`
+
+Even if a host callback existed, there's no code path that calls `ddl_execute()` on the SQLite `Connection`. The existing `host_dataview_execute` callback only calls `execute()`, which has the DDL guard (Gate 1) that rejects DDL statements.
+
+---
+
+## What works vs what doesn't
+
+| Component | Status |
+|-----------|--------|
+| `Connection::execute()` — Gate 1 DDL guard | Working — correctly rejects DDL |
+| `Connection::ddl_execute()` — SQLite impl | Working — code is correct, tests pass (`sqlite.rs:712-853`) |
+| `[init]` manifest parsing | Working — init config parsed, handler dispatched |
+| Init handler JS dispatch via ProcessPool | Working — JS executes, logs emitted |
+| `[security].ddl_whitelist` parsing | Untested — `_ddl_whitelist` param is unused |
+| `ctx.ddl()` JS → host callback → `ddl_execute()` | **NOT IMPLEMENTED** |
+| `ctx.admin()` JS → host callback | **NOT IMPLEMENTED** |
+| `ctx.query()` JS → host callback | **NOT IMPLEMENTED** |
+
+---
+
+## How to reproduce
+
+**manifest.toml:**
+```toml
+[init]
+module     = "handlers/bootstrap.js"
+entrypoint = "initialize"
+```
+
+**riversd.toml:**
+```toml
+[security]
+ddl_whitelist = [
+    "mydb@a1b2c3d4-1111-2222-3333-444455556666",
+]
+```
+
+**handlers/bootstrap.js:**
+```javascript
+async function initialize(ctx) {
+    await ctx.ddl("my_db", "CREATE TABLE test (id INTEGER PRIMARY KEY)");
+    Rivers.log.info("init done");  // This logs — init "succeeds"
+}
+```
+
+**Expected:** Table `test` created in SQLite database on disk.
+
+**Actual:** Init handler logs success. Table does not exist. All subsequent view handlers fail with `sqlite prepare: no such table: test`.
+
+**Evidence from logs:**
+```
+INFO  init handler started   app_id=a1b2c3d4... module=handlers/bootstrap.js entrypoint=initialize
+INFO  schema_bootstrap_start
+INFO  init handler completed app_id=a1b2c3d4... duration_ms=54
+```
+No errors, no DDL execution logs, no `DdlExecuted` events. DB file on disk is 4096 bytes (empty SQLite header, no tables).
+
+---
+
+## What needs to be built
+
+1. **V8 host callback for `ctx.ddl()`** — register `host_ddl_execute` (or similar) that:
+   - Receives datasource name + SQL statement from JS
+   - Looks up the datasource connection via DriverFactory/DataViewExecutor
+   - Checks `ddl_whitelist` for `"{database}@{appId}"` (Gate 3)
+   - Calls `Connection::ddl_execute()` on the resolved connection
+   - Returns result to JS
+
+2. **Wire `_executor` and `_ddl_whitelist`** in `dispatch_init_handler()` — pass them through `task_enrichment::enrich()` so the ProcessPool task has access to database connections and whitelist
+
+3. **Same for `ctx.admin()` and `ctx.query()`** — the init handler needs its own set of host callbacks distinct from view handler callbacks (no `ctx.request`, `ctx.session`, etc.)
+
+---
+
+## Also found: parameter type enforcement change (separate issue)
+
+Rivers 0.53.0 now rejects `null` for typed DataView parameters:
+
+```
+ParameterTypeMismatch { name: "cursor", expected: "string", actual: "null" }
+```
+
+Previously `null` was accepted for optional string parameters. We've fixed this on our side by omitting the parameter entirely instead of passing `null`, but this is a breaking change that should be documented in the 0.53.0 release notes.
+
+---
+
+## Impact
+
+Any application on 0.53.0 that needs schema initialization at startup is blocked. The old pattern (DDL via view handlers) is now forbidden by Gate 1, and the new pattern (DDL via init handler) is not yet functional. **There is no working DDL path in 0.53.0.**
+
+## Workaround
+
+None within Rivers. The only option is to create tables externally via `sqlite3` CLI before starting riversd, bypassing the init handler entirely.


### PR DESCRIPTION
## Summary
- Fix `ctx.ddl()` in init handlers — 3 bugs prevented DDL from executing at startup
- HOST_CONTEXT OnceLock not set before Phase 1.5 init handler dispatch
- DDL whitelist checked JS datasource name instead of resolved database path
- Whitelist used entry_point name instead of manifest UUID (added APP_ID_MAP)

## Root Cause
`set_host_context()` was called in `lifecycle.rs` **after** `load_and_wire_bundle()`, but init handlers run **inside** bundle loading. Additionally, the Gate 3 whitelist check used the wrong identifiers for both the database path and the app ID.

## Changes
| File | Change |
|------|--------|
| `bundle_loader/load.rs` | Wire HOST_CONTEXT, DDL_WHITELIST, APP_ID_MAP before Phase 1.5 |
| `engine_loader/host_callbacks.rs` | Resolve database path + UUID before whitelist check |
| `engine_loader/host_context.rs` | Add APP_ID_MAP OnceLock + setter |
| `engine_loader/mod.rs` | Export `set_app_id_map` |
| `server/lifecycle.rs` | Simplify (idempotent after bundle load wiring) |

## Test plan
- [x] Verified with IPAM team's `ddl-test-bundle` (dist/ddl-test-bundle.tar.gz)
- [x] Init handler creates SQLite table via `ctx.ddl()`
- [x] Gate 3 whitelist resolves database path + manifest UUID correctly
- [x] POST /api/items inserts rows, GET /api/items returns them
- [x] `cargo check -p riversd` clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)