### PR TITLE
fix: just deploy now builds static by default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,13 +80,13 @@ _assemble-dynamic:
 
 # ── Deploy (via cargo deploy) ────────────────────────────────────
 
-# Deploy dynamic dist to a target directory
+# Deploy static dist to a target directory (single binary, all drivers compiled in)
 deploy path:
-    cargo deploy {{path}}
-
-# Deploy static dist to a target directory
-deploy-static path:
     cargo deploy {{path}} --static
+
+# Deploy dynamic dist (thin binary + engine dylibs, static drivers)
+deploy-dynamic path:
+    cargo deploy {{path}}
 
 # ── Distribution ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `just deploy <path>` now builds static (single binary, all drivers compiled in)
- `just deploy-dynamic <path>` for thin binary + engine dylib mode

Since cdylib driver plugins are disabled in v0.54.0, static is the sensible default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)