### PR TITLE
docs: update guides with v0.54.0 changes

### DIFF
--- a/docs/guide/admin.md
+++ b/docs/guide/admin.md
@@ -1,6 +1,10 @@
 # Admin and Operations Reference
 
+**Rivers v0.54.0**
+
 This document covers administration, security, monitoring, and operational management of a Rivers deployment. All section identifiers follow the AW3 numbering scheme.
+
+> **v0.54.0 operator notes:** (1) cdylib driver plugins are disabled — all drivers are now statically compiled into `riversd`. (2) `[plugins] dir` config is deprecated and logs a warning. (3) Apps with unresolvable drivers no longer crash the whole bundle — they are isolated and return 503. (4) Metrics are now actually emitted (previously the feature scaffolding existed but no data flowed). See AW3.16, AW3.17, AW3.18 below.
 
 ---
 
@@ -430,9 +434,24 @@ rate_limit_custom_header = "X-Api-Key"     # required if strategy = custom_heade
 
 Bucket eviction occurs at 10,000 entries, removing stale or oldest buckets first.
 
-WebSocket connections use per-connection rate limiting. REST and SSE use per-IP rate limiting. Per-view overrides can be configured in individual view definitions.
+WebSocket connections use per-connection rate limiting. REST and SSE use per-IP rate limiting. Per-view overrides can be configured in individual view definitions (see below).
 
-When rate-limited, the response is `429 Too Many Requests` with `Retry-After` header.
+### Per-view rate limiting (v0.54.0)
+
+Individual views can override the global rate limit by declaring `rate_limit_per_minute` and `rate_limit_burst_size` directly on the view in `app.toml`:
+
+```toml
+[api.views.search]
+path                  = "/api/search"
+method                = "GET"
+view_type             = "Rest"
+rate_limit_per_minute = 30     # override global (120)
+rate_limit_burst_size = 10     # override global (60)
+```
+
+Per-view limits use token-bucket algorithm with **proxy-aware** client IP extraction: when the request arrives from an IP in `trusted_proxies`, the left-most entry in `X-Forwarded-For` is used as the client key. Limiters are cached per view_id.
+
+When a per-view limit is exceeded, the response is `429 Too Many Requests` with a `Retry-After` header set to the seconds remaining until the next token is available.
 
 ### CSRF protection
 
@@ -742,13 +761,18 @@ port = 9091       # default
 
 Scrape endpoint: `http://localhost:9091/metrics`
 
-Available metrics:
-- `rivers_http_requests_total` -- counter by method and status
-- `rivers_http_request_duration_ms` -- histogram by method
-- `rivers_engine_executions_total` -- counter by engine and success
-- `rivers_engine_execution_duration_ms` -- histogram by engine
-- `rivers_active_connections` -- gauge
-- `rivers_loaded_apps` -- gauge
+Available metrics (v0.54.0 — now actually wired to emit data):
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `rivers_http_requests_total` | counter | `method`, `status` |
+| `rivers_http_request_duration_ms` | histogram | `method` |
+| `rivers_active_connections` | gauge | — |
+| `rivers_engine_executions_total` | counter | `engine` (`v8` \| `dataview` \| `none`), `success` (`true` \| `false`) |
+| `rivers_engine_execution_duration_ms` | histogram | `engine` |
+| `rivers_loaded_apps` | gauge | — |
+
+All metrics are behind the `metrics` cargo feature. In deployed builds, the feature is enabled by default.
 
 ### Environment overrides
 
@@ -1080,3 +1104,181 @@ Scripts must follow this I/O contract:
 - [ ] `integrity_check = "each_time"` for sensitive commands
 - [ ] JSON Schema validation enabled for all commands that accept user input
 - [ ] `max_concurrent` limits set to prevent resource exhaustion
+
+---
+
+## AW3.16 Missing Driver Handling (v0.54.0)
+
+When an app declares datasources with drivers that cannot be resolved, the failure is isolated to that app rather than aborting the whole bundle.
+
+### Behavior
+
+- The app is **blocked from loading**. Its views are **not** registered in the router.
+- Init handlers for the failed app are **skipped**.
+- Requests to endpoints in the failed app return `503 Service Unavailable`:
+
+  ```json
+  {
+    "code": 503,
+    "message": "app 'canary-nosql' is unavailable — missing driver(s): mongodb, elasticsearch"
+  }
+  ```
+
+- Other apps in the same bundle load and serve traffic normally.
+- A structured `AppLoadFailed` event is written to `log/apps/<app>.log` listing the missing driver names and the resources that referenced them.
+
+### Operator checklist
+
+1. Check `log/apps/<app>.log` for the `AppLoadFailed` event.
+2. If the missing driver comes from a `[plugins] dir` entry, remove that config key — all drivers are now compiled into `riversd` (see AW3.18).
+3. Verify `resources.toml` uses a known driver name (`postgres`, `mysql`, `sqlite`, `redis`, `faker`, `mongodb`, `elasticsearch`, `couchdb`, `cassandra`, `ldap`, `kafka`, `rabbitmq`, `nats`, `neo4j`, `influxdb`, `redis-streams`, `exec`).
+
+### Failed app tracking
+
+`riversd` keeps a `failed_apps` registry in memory. The router middleware consults it before dispatching — any request whose app is in `failed_apps` short-circuits to 503 with the structured error body above. On a successful hot reload that fixes the missing driver, the app is removed from `failed_apps` and its views begin serving normally.
+
+---
+
+## AW3.17 Startup Bundle Validation (v0.54.0)
+
+`riversd` runs the `riverpackage` 4-layer validation pipeline at startup before loading the bundle. Invalid bundles are **rejected** before any driver is initialized.
+
+The pipeline layers:
+
+1. **Structural** — TOML parse of bundle/app manifests, `resources.toml`, `app.toml`
+2. **Existence** — all referenced files (schemas, handler modules, libraries) exist
+3. **Cross-reference** — DataViews resolve to datasources, views resolve to DataViews, services resolve
+4. **Syntax** — JSON schemas parse, TS/JS handler modules compile via V8
+
+Run the same pipeline locally or in CI with:
+
+```bash
+riverpackage validate ./my-bundle
+riverpackage validate ./my-bundle --format json
+riverpackage validate ./my-bundle --config /opt/rivers/config/riversd.toml
+```
+
+A bundle that passes `riverpackage validate` on the same Rivers version will load cleanly on the server.
+
+---
+
+## AW3.18 Static Plugin Mode and the Deprecated `[plugins] dir` (v0.54.0)
+
+### Background
+
+Prior to v0.54.0, driver plugins (`mongodb`, `elasticsearch`, `couchdb`, `cassandra`, `ldap`, `kafka`, `rabbitmq`, `nats`, `neo4j`, `influxdb`, `redis-streams`, `exec`) shipped as cdylib files in `plugins/` and were loaded by `riversd` at startup. In testing, this produced SIGABRT crashes caused by a **tokio ABI mismatch across the FFI boundary** — the tokio runtime inside the plugin and the one inside `riversd` did not agree on type layout.
+
+### Current behavior
+
+- cdylib plugin loading is **disabled**.
+- All 12 former plugin drivers, plus the 5 built-in drivers (`sqlite`, `postgres`, `mysql`, `redis`, `faker`), are compiled into the `riversd` binary via the `static-plugins` cargo feature.
+- The `[plugins] dir` config key is **deprecated**. If set, `riversd` logs a warning at startup and proceeds without loading anything from the directory.
+
+### Config migration
+
+Remove the `[plugins]` section from your `riversd.toml`:
+
+```toml
+# DELETE in v0.54.0 — no longer has any effect
+# [plugins]
+# dir = "/opt/rivers/plugins"
+```
+
+Engine dylibs (`librivers_engine_v8`, `librivers_engine_wasm`) are unaffected — they still ship as dylibs in dynamic-mode deploys under `[engines] dir`.
+
+### Future: Plugin ABI v2
+
+A new plugin ABI is planned to re-enable dynamic driver loading. It uses a **synchronous C-ABI** that avoids the tokio-across-FFI problem entirely: plugins expose blocking functions and `riversd` wraps them in `tokio::task::spawn_blocking` on its side. See `docs/arch/rivers-plugin-abi-v2-spec.md` for the design.
+
+---
+
+## AW3.19 Guard Lifecycle Hooks (v0.54.0)
+
+Guard views (views with `guard = true`, typically login endpoints) can now declare fire-and-forget lifecycle hooks that fire at key points in the session lifetime. Hooks are dispatched via `tokio::spawn` and **cannot influence the auth flow** — they run concurrently with the response and are intended for side-effects only (audit logging, metrics, external event emission).
+
+### Configuration
+
+```toml
+[api.views.login]
+path      = "/api/login"
+method    = "POST"
+view_type = "Rest"
+auth      = "none"
+guard     = true
+
+[api.views.login.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/auth.ts"
+entrypoint = "login"
+
+[api.views.login.lifecycle_hooks]
+on_session_valid.module      = "libraries/handlers/audit.ts"
+on_session_valid.entrypoint  = "onSessionValid"
+on_invalid_session.module    = "libraries/handlers/audit.ts"
+on_invalid_session.entrypoint = "onInvalidSession"
+on_failed.module             = "libraries/handlers/audit.ts"
+on_failed.entrypoint         = "onLoginFailed"
+```
+
+### Hooks
+
+| Hook | Fires when |
+|------|-----------|
+| `on_session_valid` | A session validation check succeeds (e.g., a protected request arrives with a still-valid session). |
+| `on_invalid_session` | A session validation check fails (expired, revoked, unknown token). |
+| `on_failed` | Guard credentials are rejected (wrong password, unknown user). |
+
+### Contract
+
+- Hooks are **fire-and-forget**. Return values are ignored.
+- Hooks **cannot block** or extend the request. They must not perform long-running work.
+- Hooks run in the ProcessPool on a best-effort basis. A hook failure does not affect the originating request.
+- Hook handlers receive the same `ctx` shape as normal CodeComponent handlers but should treat it as read-only.
+
+---
+
+## AW3.20 DDL in Init Handlers (v0.54.0)
+
+Init handlers (TypeScript / JavaScript modules that run once per app at load time) can now execute DDL statements against a datasource via `ctx.ddl(datasource, statement)`. This is useful for creating tables, indexes, or other schema objects during app startup — for example, a canary app that wants to seed its own test schema.
+
+### Handler usage
+
+```typescript
+// libraries/handlers/init.ts
+export function init(ctx: InitContext): void {
+  ctx.ddl("orders_db", "CREATE TABLE IF NOT EXISTS audit_log (id SERIAL PRIMARY KEY, message TEXT)");
+  ctx.ddl("orders_db", "CREATE INDEX IF NOT EXISTS idx_audit_log_id ON audit_log (id)");
+}
+```
+
+### Gate 3 whitelist
+
+DDL execution is gated by a `ddl_whitelist` in `[security]`. Each entry is `"<datasource>@<app_id>"`:
+
+```toml
+[security]
+ddl_whitelist = [
+  "orders_db@c7a3e1f0-8b2d-4d6e-9f1a-3c5b7d9e2f4a",
+  "audit_db@c7a3e1f0-8b2d-4d6e-9f1a-3c5b7d9e2f4a",
+]
+```
+
+A `ctx.ddl(...)` call from an app that is not on the whitelist for the requested datasource is **rejected** at the gate. The init handler receives an error and the rejection is logged.
+
+### Events
+
+DDL calls emit structured events to the per-app log (`log/apps/<app>.log`):
+
+| Event | Level | When |
+|-------|-------|------|
+| `DdlExecuted` | Info | Statement executed successfully. |
+| `DdlFailed` | Error | Statement reached the datasource but failed (syntax error, permission denied, etc.). |
+| `DdlRejected` | Warn | Statement blocked at Gate 3 — datasource@app_id not in `ddl_whitelist`. |
+
+### Engine support
+
+`ctx.ddl` works in both execution modes:
+
+- **Static builds** — ProcessPool V8 (compiled in)
+- **Dynamic builds** — engine dylib V8 (loaded from `lib/librivers_engine_v8.dylib`)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,6 +1,10 @@
 # CLI Reference
 
+**Rivers v0.54.0**
+
 Rivers ships five binaries: `riversd`, `riversctl`, `rivers-lockbox`, `rivers-keystore`, and `riverpackage`.
+
+> **v0.54.0:** In static builds (the default for `just deploy`), `riversd` is a single fat binary with all drivers and engines compiled in. Dynamic builds (`just deploy-dynamic` or `cargo deploy`) still produce a thin `riversd` plus engine dylibs in `lib/`. cdylib driver plugins are disabled — see the installation guide.
 
 ---
 
@@ -221,14 +225,36 @@ Key differences from `rivers-lockbox`:
 
 Bundle packaging and validation tool.
 
-| Flag | Description |
-|------|-------------|
-| `--pre-flight <bundle_dir>` | Validate bundle structure without starting the server. |
+### riverpackage validate (v0.54.0 — 4-layer pipeline)
 
-Checks: manifest, app configs, schema files, datasource references, DataView references.
+Runs the 4-layer bundle validation pipeline. This is the same pipeline `riversd` runs at startup, so a bundle that passes `riverpackage validate` will load cleanly on a correctly-configured server.
 
 ```sh
-riverpackage --pre-flight ./address-book-bundle
+riverpackage validate ./address-book-bundle
+riverpackage validate ./address-book-bundle --format json
+riverpackage validate ./address-book-bundle --config /opt/rivers/config/riversd.toml
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format <text\|json>` | Output format. Default `text`. |
+| `--config <path>` | Path to `riversd.toml`. Required when you want the syntax layer to compile TS/JS handlers via the V8 engine located by the config. |
+
+The pipeline:
+
+1. **Structural** — TOML parse of bundle manifest, app manifests, `resources.toml`, `app.toml`
+2. **Existence** — all referenced files (schemas, handler modules, libraries) exist on disk
+3. **Cross-reference** — DataViews resolve to declared datasources, views resolve to DataViews, services resolve
+4. **Syntax** — JSON schemas parse, TS/JS handler modules compile via embedded V8
+
+Exit code is non-zero on any layer failure. JSON output includes per-layer results for scripting.
+
+### riverpackage preflight
+
+Legacy preflight checks (kept for backwards compatibility). New CI pipelines should use `validate` instead.
+
+```sh
+riverpackage preflight ./address-book-bundle
 ```
 
 ### riverpackage init

--- a/docs/guide/developer.md
+++ b/docs/guide/developer.md
@@ -1,6 +1,10 @@
 # Rivers Developer Guide
 
+**Rivers v0.54.0**
+
 Build applications with TOML configuration and JSON schemas. No Rust required.
+
+> **v0.54.0:** All driver plugins are now compiled into `riversd`. There is no longer a distinction between "built-in" and "plugin" drivers from the developer's perspective — any driver name you declare will resolve if it's listed in the driver table below. See [Available Drivers](#available-drivers).
 
 ---
 
@@ -97,27 +101,33 @@ failure_threshold  = 5
 open_timeout_ms    = 30000
 ```
 
-### Available Drivers
+### Available Drivers (v0.54.0)
 
-| Driver | Type | Package |
-|--------|------|---------|
-| `postgres` | Database | Built-in |
-| `mysql` | Database | Built-in |
-| `sqlite` | Database | Built-in |
-| `redis` | Database | Built-in |
-| `memcached` | Database | Built-in |
-| `faker` | Database | Built-in (synthetic test data) |
-| `eventbus` | Database | Built-in (pub/sub) |
-| `mongodb` | Database | Plugin |
-| `elasticsearch` | Database | Plugin |
-| `cassandra` | Database | Plugin |
-| `couchdb` | Database | Plugin |
-| `influxdb` | Database | Plugin |
-| `ldap` | Database | Plugin |
-| `kafka` | Broker | Plugin |
-| `rabbitmq` | Broker | Plugin |
-| `nats` | Broker | Plugin |
-| `redis-streams` | Broker | Plugin |
+All drivers are compiled into `riversd` via the `static-plugins` cargo feature. There are no external plugin dylibs in v0.54.0.
+
+| Driver | Type | Notes |
+|--------|------|-------|
+| `postgres` | Database | Core |
+| `mysql` | Database | Core |
+| `sqlite` | Database | Core |
+| `redis` | Database | Core |
+| `memcached` | Database | Core |
+| `faker` | Database | Synthetic data generator |
+| `eventbus` | Database | Pub/sub |
+| `mongodb` | Database | Formerly cdylib, now static |
+| `elasticsearch` | Database | Formerly cdylib, now static |
+| `cassandra` | Database | Formerly cdylib, now static |
+| `couchdb` | Database | Formerly cdylib, now static |
+| `influxdb` | Database | Formerly cdylib, now static |
+| `neo4j` | Database | Formerly cdylib, now static |
+| `ldap` | Database | Formerly cdylib, now static |
+| `kafka` | Broker | Formerly cdylib, now static |
+| `rabbitmq` | Broker | Formerly cdylib, now static |
+| `nats` | Broker | Formerly cdylib, now static |
+| `redis-streams` | Broker | Formerly cdylib, now static |
+| `exec` | Database | Script runner, formerly cdylib, now static |
+
+If an app declares a datasource whose driver cannot be resolved, the app is isolated: its views are blocked from loading and endpoint requests return `503 Service Unavailable`. Other apps in the bundle load normally. See `admin.md` AW3.16 for operator details.
 
 ### Faker Driver (Testing)
 
@@ -293,6 +303,21 @@ auth = "session"    # Protected — requires valid session
 guard = true        # This view IS the login endpoint
 ```
 
+### Per-view Rate Limiting (v0.54.0)
+
+Views can override the global rate limit with their own token-bucket settings:
+
+```toml
+[api.views.search]
+path                  = "search"
+method                = "GET"
+view_type             = "Rest"
+rate_limit_per_minute = 30
+rate_limit_burst_size = 10
+```
+
+Per-view limiters use proxy-aware client IP extraction (respects `X-Forwarded-For` from `trusted_proxies`). Exceeding the limit returns `429 Too Many Requests` with a `Retry-After` header.
+
 ---
 
 ## CodeComponent Handlers (JavaScript)
@@ -361,6 +386,39 @@ function handler(ctx) {
 ```
 
 Reserved key prefixes (`session:`, `csrf:`, `poll:`, `cache:`, `rivers:`) are blocked.
+
+### Init Handlers and `ctx.ddl` (v0.54.0)
+
+Init handlers run once per app at load time. They can execute DDL statements to create tables, indexes, or other schema objects:
+
+```typescript
+// libraries/handlers/init.ts
+export function init(ctx) {
+  ctx.ddl("orders_db", "CREATE TABLE IF NOT EXISTS audit_log (id SERIAL PRIMARY KEY, message TEXT)");
+  ctx.ddl("orders_db", "CREATE INDEX IF NOT EXISTS idx_audit_log_id ON audit_log (id)");
+}
+```
+
+`ctx.ddl(datasource, statement)` executes the statement against the named datasource. DDL calls are gated by a **Gate 3 whitelist** configured in `riversd.toml`:
+
+```toml
+[security]
+ddl_whitelist = [
+  "orders_db@c7a3e1f0-8b2d-4d6e-9f1a-3c5b7d9e2f4a",
+]
+```
+
+Calls from apps not on the whitelist for the requested datasource are rejected at the gate.
+
+DDL events are logged to the per-app log:
+
+| Event | Level | When |
+|-------|-------|------|
+| `DdlExecuted` | info | Statement executed successfully |
+| `DdlFailed` | error | Statement reached the datasource but failed |
+| `DdlRejected` | warn | Blocked at Gate 3 whitelist |
+
+`ctx.ddl` works in both ProcessPool V8 (static builds) and engine dylib V8 (dynamic builds).
 
 ### `Rivers.log` (Structured Logging)
 
@@ -508,6 +566,28 @@ language   = "javascript"
 module     = "handlers/auth.js"
 entrypoint = "authenticate"
 ```
+
+### Guard Lifecycle Hooks (v0.54.0)
+
+Guard views can declare fire-and-forget lifecycle hooks that fire when session state changes. Hooks run via `tokio::spawn` and **cannot influence the auth flow** — they exist for audit logging, metrics, and external event emission.
+
+```toml
+[api.views.login.lifecycle_hooks]
+on_session_valid.module      = "handlers/audit.js"
+on_session_valid.entrypoint  = "onSessionValid"
+on_invalid_session.module    = "handlers/audit.js"
+on_invalid_session.entrypoint = "onInvalidSession"
+on_failed.module             = "handlers/audit.js"
+on_failed.entrypoint         = "onLoginFailed"
+```
+
+| Hook | Fires when |
+|------|-----------|
+| `on_session_valid` | Session validation check succeeds on a protected request. |
+| `on_invalid_session` | Session validation check fails (expired, revoked, unknown). |
+| `on_failed` | Guard credentials are rejected. |
+
+Hooks are fire-and-forget. Return values are ignored. Hooks must not block or perform long-running work — they run concurrently with the originating request and their failures do not affect it.
 
 ### WASM Handlers
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,6 +1,8 @@
 # Rivers Installation and Operations Guide
 
-Version 0.1.0
+Version 0.54.0
+
+> **v0.54.0 highlights:** All driver plugins are now compiled statically into `riversd`. The cdylib plugin mechanism is temporarily disabled due to a tokio ABI mismatch across FFI that caused SIGABRT crashes. See [AW1.2 Building from Source](#aw12-building-from-source) and [AW1.13 Missing Driver Handling](#aw113-missing-driver-handling) below.
 
 ---
 
@@ -59,38 +61,68 @@ codegen-units = 1
 strip = "symbols"
 ```
 
-### Deploying with cargo deploy
+### Deploying with cargo deploy and just
 
-`cargo deploy` builds and assembles a complete Rivers instance:
+Rivers ships two deploy entry points:
+
+**`just deploy <path>`** (recommended, v0.54.0+) — static mode by default. Produces a single fat `riversd` binary with all drivers compiled in. No separate plugin dylibs.
+
+```bash
+just deploy /opt/rivers                # static (default)
+just deploy-dynamic /opt/rivers        # thin binary + engine dylibs
+```
+
+**`cargo deploy <path>`** — dynamic mode by default (thin binary + engine dylibs).
 
 ```bash
 # Install the deploy tool (once)
 cargo install --path crates/cargo-deploy
 
-# Dynamic mode — thin binaries + shared engine/plugin libraries
+# Dynamic mode — thin binary + engine dylibs (V8, WASM) in lib/
 cargo deploy /opt/rivers
 
-# Static mode — single fat binary
+# Static mode — single fat binary, all drivers compiled in
 cargo deploy /opt/rivers --static
 ```
 
-Output structure:
+> **v0.54.0 change:** `just deploy` now defaults to **static** builds. Previously it produced dynamic-mode deployments. Use `just deploy-dynamic` for the old behavior. `cargo deploy` still defaults to dynamic mode for backwards compatibility.
+
+Output structure (static, v0.54.0+):
+
 ```
 /opt/rivers/
-├── bin/           (riversd, riversctl, rivers-lockbox, rivers-keystore, riverpackage)
-├── lib/           (librivers_engine_v8.dylib, librivers_engine_wasm.dylib)
-├── plugins/       (12 driver plugin dylibs)
+├── bin/
+│   └── riversd                        (single fat binary — all drivers + engines)
 ├── config/
-│   ├── riversd.toml  (pre-configured with absolute paths)
-│   └── tls/          (auto-generated self-signed cert)
-├── lockbox/       (initialized with identity key)
+│   ├── riversd.toml                    (pre-configured with absolute paths)
+│   └── tls/                            (auto-generated self-signed cert)
+├── docs/
+│   └── guide/                          (NEW in v0.54.0 — user guides shipped with deploy)
+├── lockbox/
 ├── log/
-│   └── apps/      (per-app log files created at runtime)
-├── run/           (PID file written on start)
-├── apphome/       (place bundles here)
+│   └── apps/
+├── run/
+├── apphome/
 ├── data/
 └── VERSION
 ```
+
+Output structure (dynamic):
+
+```
+/opt/rivers/
+├── bin/                                (thin binaries)
+├── lib/                                (librivers_engine_v8.dylib, librivers_engine_wasm.dylib)
+├── config/
+│   └── riversd.toml
+├── docs/
+│   └── guide/                          (NEW in v0.54.0)
+...
+```
+
+> **v0.54.0:** cdylib driver plugins are no longer emitted. The `plugins/` directory is not created. All drivers (sqlite, postgres, mysql, redis, faker, plus mongodb, elasticsearch, couchdb, cassandra, ldap, kafka, rabbitmq, nats, neo4j, influxdb, redis-streams, exec) are compiled into `riversd` via the `static-plugins` feature. See [AW1.13 Missing Driver Handling](#aw113-missing-driver-handling).
+
+> **v0.54.0:** `cargo deploy <path>` now copies `docs/guide/` into `<path>/docs/guide/`. User-facing documentation ships alongside the binaries.
 
 All paths in `riversd.toml` are absolute -- binaries work from any directory.
 
@@ -181,7 +213,7 @@ Checks performed:
 - LockBox keystore permissions (if configured)
 - TLS certificate exists and is not expired
 - Log directories exist and are writable
-- Engine and plugin directories exist (dynamic mode)
+- Engine directory exists (dynamic mode only — static mode has no external dylibs)
 - Bundle path is valid
 
 **`--fix` auto-repairs:**
@@ -593,13 +625,18 @@ port = 9091       # default
 
 Scrape endpoint: `http://localhost:9091/metrics`
 
-Available metrics:
-- `rivers_http_requests_total` -- counter by method and status
-- `rivers_http_request_duration_ms` -- histogram by method
-- `rivers_engine_executions_total` -- counter by engine and success
-- `rivers_engine_execution_duration_ms` -- histogram by engine
-- `rivers_active_connections` -- gauge
-- `rivers_loaded_apps` -- gauge
+Available metrics (v0.54.0 — metrics are now actually wired and emit data when the `metrics` feature is enabled):
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `rivers_http_requests_total` | counter | `method`, `status` |
+| `rivers_http_request_duration_ms` | histogram | `method` |
+| `rivers_active_connections` | gauge | — |
+| `rivers_engine_executions_total` | counter | `engine` (`v8` \| `dataview` \| `none`), `success` |
+| `rivers_engine_execution_duration_ms` | histogram | `engine` |
+| `rivers_loaded_apps` | gauge | — |
+
+Default port: `9091`. Scrape endpoint: `http://localhost:9091/metrics`.
 
 ### Backpressure
 
@@ -958,17 +995,73 @@ max_complexity = 1000
 # pool_size = 20
 ```
 
-### Bundle validation
+### Bundle validation (v0.54.0 — 4-layer pipeline)
 
-Before deploying a bundle, validate it:
+Before deploying a bundle, validate it with the 4-layer validation pipeline:
 
 ```bash
-# Structure and TOML/JSON syntax check
+# Full 4-layer validation (text output)
 riverpackage validate bundles/my-app-bundle
 
-# Full preflight: validate + check schema/parameter orphans
-riverpackage preflight bundles/my-app-bundle
+# Machine-readable JSON output
+riverpackage validate bundles/my-app-bundle --format json
+
+# Pass a riversd.toml so validation can discover engines (for TS/JS compile checks)
+riverpackage validate bundles/my-app-bundle --config /opt/rivers/config/riversd.toml
 
 # Package into a tar.gz archive
 riverpackage pack bundles/my-app-bundle output.tar.gz
 ```
+
+The pipeline runs four layers in order:
+
+1. **Structural** — TOML parse of `manifest.toml`, per-app `manifest.toml`, `resources.toml`, `app.toml`
+2. **Existence** — all referenced files (schemas, handler modules, libraries) exist on disk
+3. **Cross-reference** — DataViews resolve to declared datasources, views resolve to DataViews, services resolve across apps
+4. **Syntax verification** — JSON schemas parse, handler TypeScript/JavaScript modules compile successfully via an embedded V8 check
+
+`riversd` itself runs this same pipeline at startup. Invalid bundles are rejected **before** loading, so you can catch issues in CI with `riverpackage validate` without launching the server.
+
+---
+
+## AW1.13 Missing Driver Handling
+
+**New in v0.54.0.** When an app declares datasources whose drivers cannot be resolved, Rivers now isolates the failure to that app rather than aborting the whole bundle.
+
+### Behavior
+
+- The failing app is **blocked from loading** — its views are **not** registered in the router.
+- Init handlers for the failed app are **skipped**.
+- Requests to endpoints in the failed app return `503 Service Unavailable`:
+
+  ```json
+  {
+    "code": 503,
+    "message": "app 'canary-nosql' is unavailable — missing driver(s): mongodb, elasticsearch"
+  }
+  ```
+
+- Other apps in the same bundle load normally. If `canary-nosql` fails but `canary-sql` is healthy, requests to `canary-sql` succeed.
+- A structured `AppLoadFailed` event is emitted to the per-app log at `log/apps/<app>.log` with the list of missing drivers and the resource that referenced each one.
+- The main `riversd.log` also records a warning.
+
+### Operator checklist
+
+If an app is returning 503 with "unavailable":
+
+1. Check `log/apps/<app>.log` for the `AppLoadFailed` event and the list of missing driver names.
+2. For v0.54.0: most missing-driver errors come from stale configs that still reference drivers by their old cdylib names or from an unknown driver name. Every built-in and plugin driver is compiled into `riversd` — drivers should always resolve.
+3. If you were previously loading a plugin from `[plugins] dir`, remove that config line (see below) — the driver is now built in.
+4. Fix `resources.toml` / `app.toml` to reference a known driver name.
+
+### Deprecated: `[plugins] dir`
+
+The `[plugins] dir` config key is **deprecated** in v0.54.0. Setting it logs a warning and has no effect. cdylib plugin loading is disabled because of a tokio ABI mismatch across FFI that caused SIGABRT crashes. All 12 former plugin drivers (mongodb, elasticsearch, couchdb, cassandra, ldap, kafka, rabbitmq, nats, neo4j, influxdb, redis-streams, exec) are now compiled statically via the `static-plugins` feature.
+
+```toml
+# REMOVE this from riversd.toml — deprecated in v0.54.0
+# [plugins]
+# dir = "/opt/rivers/plugins"
+```
+
+Dynamic plugin loading is planned to return via **Plugin ABI v2**, a synchronous C-ABI that avoids the tokio-across-FFI problem. See `docs/arch/rivers-plugin-abi-v2-spec.md` for the design.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,5 +1,7 @@
 # Quick Start
 
+**Rivers v0.54.0**
+
 Get a Rivers app running in under five minutes. No database required -- the bundled address-book example uses synthetic data.
 
 ---
@@ -24,15 +26,26 @@ cd rivers
 cargo build --release
 ```
 
-This produces three binaries in `target/release/`:
+This produces binaries in `target/release/`:
 
 | Binary | Purpose |
 |--------|---------|
-| `riversd` | Application server |
+| `riversd` | Application server (v0.54.0 — single fat binary, all drivers compiled in) |
 | `riversctl` | CLI management tool |
-| `riverpackage` | Bundle packaging tool |
+| `riverpackage` | Bundle validation and packaging tool |
+| `rivers-lockbox` | Secret keystore CLI |
+| `rivers-keystore` | Per-app encryption key CLI |
 
 For development, use debug builds (`cargo build`) -- faster compilation, slower runtime.
+
+### Deploying a full instance
+
+```bash
+just deploy /opt/rivers               # v0.54.0: static build (default)
+just deploy-dynamic /opt/rivers       # thin binary + engine dylibs in lib/
+```
+
+`just deploy` also copies `docs/guide/` into `/opt/rivers/docs/guide/` (new in v0.54.0).
 
 ---
 
@@ -353,8 +366,9 @@ Required parameters become non-nullable arguments. Parameters with defaults beco
 
 ## Next Steps
 
-- Swap the `faker` driver for `postgres`, `mysql`, or `sqlite` to use a real database
-- Add authentication (`auth = "jwt"` or `auth = "session"`) to views
-- Add a `CodeComponent` handler for custom business logic via WASM
-- Package the bundle with `riverpackage` for deployment
-- See `docs/arch/` for the full specification set
+- Swap the `faker` driver for `postgres`, `mysql`, or `sqlite` to use a real database. In v0.54.0 all 17 drivers (core + former plugins) are compiled into `riversd` and resolve by name — no plugin directory needed.
+- Add authentication (`auth = "session"`) to views and a guard view with `guard = true`
+- Add a `CodeComponent` handler for custom business logic via V8 or WASM
+- Run the 4-layer validation pipeline: `riverpackage validate ./address-book-bundle`
+- Enable Prometheus metrics on port 9091: `[metrics] enabled = true`
+- See `docs/arch/` for the full specification set and `docs/guide/` for the rest of the user guides

--- a/docs/guide/rivers-app-development.md
+++ b/docs/guide/rivers-app-development.md
@@ -1,6 +1,8 @@
 # Rivers Application Development — Build Spec
 
-**Rivers v0.50.1**
+**Rivers v0.54.0**
+
+> **v0.54.0 changes for bundle authors:** (1) All drivers are compiled into `riversd` — no external plugin dylibs. (2) Init handlers can call `ctx.ddl()` to run DDL on app load. (3) Views support `rate_limit_per_minute` / `rate_limit_burst_size` for per-view rate limiting. (4) Guard views support fire-and-forget `lifecycle_hooks`. (5) `riverpackage validate` now runs a 4-layer validation pipeline, and `riversd` runs the same pipeline at startup.
 
 ## What You Are Building
 
@@ -170,7 +172,9 @@ required = true
 
 MUST: `appId` matches the app-service's `manifest.toml` appId exactly.
 
-### Supported Drivers
+### Supported Drivers (v0.54.0)
+
+All drivers are compiled into `riversd` — there are no external plugin dylibs in v0.54.0.
 
 | Driver | x-type | Credentials | Use Case |
 |--------|--------|-------------|----------|
@@ -179,9 +183,21 @@ MUST: `appId` matches the app-service's `manifest.toml` appId exactly.
 | `mysql` | `mysql` | lockbox | Relational data |
 | `sqlite` | `sqlite` | `nopassword = true` | Embedded relational |
 | `redis` | `redis` | lockbox | Cache, sessions, KV, streams |
+| `mongodb` | `mongodb` | lockbox | Document store |
+| `elasticsearch` | `elasticsearch` | optional | Search / analytics |
+| `couchdb` | `couchdb` | lockbox | Document store |
+| `cassandra` | `cassandra` | lockbox | Wide-column |
+| `neo4j` | `neo4j` | lockbox | Graph |
+| `influxdb` | `influxdb` | lockbox | Time-series |
+| `ldap` | `ldap` | lockbox | Directory |
 | `http` | `http` | optional | External API proxy |
 | `kafka` | `kafka` | lockbox | Message streaming |
-| `ldap` | `ldap` | lockbox | Directory |
+| `rabbitmq` | `rabbitmq` | lockbox | Message queue |
+| `nats` | `nats` | optional | Message broker |
+| `redis-streams` | `redis-streams` | lockbox | Stream broker |
+| `rivers-exec` | `exec` | `nopassword = true` | Script execution |
+
+If a declared driver cannot be resolved at startup, the entire app is blocked from loading and its endpoints return `503 Service Unavailable`. Other apps in the bundle load normally.
 
 ---
 
@@ -624,6 +640,76 @@ resources  = ["users_db"]
 |-------|--------|-------|
 | `auth` | `"none"`, `"session"` | `"none"` — no authentication check; `"session"` — requires valid session token |
 | `guard` | `true`, `false` | When `true`, marks this view as a login/auth guard endpoint that creates sessions |
+| `rate_limit_per_minute` | integer | v0.54.0 — per-view token-bucket limit (overrides global) |
+| `rate_limit_burst_size` | integer | v0.54.0 — burst capacity for per-view limit |
+
+### Per-view Rate Limiting (v0.54.0)
+
+Views can declare their own token-bucket rate limits:
+
+```toml
+[api.views.search]
+path                  = "/api/search"
+method                = "GET"
+view_type             = "Rest"
+rate_limit_per_minute = 30
+rate_limit_burst_size = 10
+```
+
+Client IP is proxy-aware: when the request comes from a trusted proxy, the left-most `X-Forwarded-For` entry is used as the key. Per-view limiters are cached by view_id. Exceeding the limit returns `429 Too Many Requests` with a `Retry-After` header.
+
+### Guard Lifecycle Hooks (v0.54.0)
+
+Guard views can declare fire-and-forget hooks that fire on session state changes. Hooks run via `tokio::spawn` and **cannot influence the auth flow** — use them only for audit logging, metrics, or external event emission.
+
+```toml
+[api.views.login]
+path      = "/api/login"
+method    = "POST"
+view_type = "Rest"
+auth      = "none"
+guard     = true
+
+[api.views.login.lifecycle_hooks]
+on_session_valid.module       = "libraries/handlers/audit.ts"
+on_session_valid.entrypoint   = "onSessionValid"
+on_invalid_session.module     = "libraries/handlers/audit.ts"
+on_invalid_session.entrypoint = "onInvalidSession"
+on_failed.module              = "libraries/handlers/audit.ts"
+on_failed.entrypoint          = "onLoginFailed"
+```
+
+| Hook | Fires when |
+|------|-----------|
+| `on_session_valid` | Session validation succeeds on a protected request. |
+| `on_invalid_session` | Session validation fails (expired, revoked, unknown). |
+| `on_failed` | Guard credentials rejected. |
+
+MUST NOT: Block or perform long-running work in a hook — they run concurrently with the request and their return values are ignored.
+
+### Init Handlers and `ctx.ddl` (v0.54.0)
+
+Apps can declare an init handler that runs once on app load. Init handlers can execute DDL via `ctx.ddl(datasource, statement)` — useful for seeding test schemas in canary apps or creating audit tables at deploy time.
+
+```typescript
+// libraries/handlers/init.ts
+export function init(ctx: InitContext): void {
+  ctx.ddl("orders_db", "CREATE TABLE IF NOT EXISTS audit_log (id SERIAL PRIMARY KEY, message TEXT)");
+}
+```
+
+DDL is gated by a **Gate 3 whitelist** in `riversd.toml` (admin-controlled, not bundle-controlled):
+
+```toml
+[security]
+ddl_whitelist = [
+  "orders_db@c7a3e1f0-8b2d-4d6e-9f1a-3c5b7d9e2f4a",
+]
+```
+
+Calls from apps not on the whitelist for the requested datasource are rejected at the gate. DDL events (`DdlExecuted`, `DdlFailed`, `DdlRejected`) are logged to the per-app log.
+
+Init handlers do **not** run for apps that are blocked by the missing-driver check — the app is isolated before init.
 
 ---
 
@@ -757,6 +843,11 @@ MUST: Append decisions, gaps, and ambiguities — never replace.
 # Build SPA (if applicable)
 cd {app-main}/libraries && npm install && npm run build
 
+# v0.54.0 — run the 4-layer validation pipeline before deploying
+riverpackage validate ./{bundle-name}
+riverpackage validate ./{bundle-name} --format json
+riverpackage validate ./{bundle-name} --config /opt/rivers/config/riversd.toml
+
 # Start services first
 riversd --config {app-service}/app.toml
 
@@ -770,6 +861,15 @@ curl "http://localhost:{port}/api/{endpoint}?limit=10"
 # SPA
 open http://localhost:{port}
 ```
+
+The `riverpackage validate` pipeline runs four layers:
+
+1. **Structural** — TOML parse of bundle/app manifests, `resources.toml`, `app.toml`
+2. **Existence** — all referenced files (schemas, handler modules, libraries) exist
+3. **Cross-reference** — DataViews resolve to datasources, views resolve to DataViews, services resolve
+4. **Syntax** — JSON schemas parse, TS/JS handler modules compile via V8
+
+`riversd` runs the same pipeline at startup. A bundle that passes `riverpackage validate` on the same Rivers version loads cleanly on the server.
 
 ---
 

--- a/docs/guide/rivers-v1-admin.md
+++ b/docs/guide/rivers-v1-admin.md
@@ -1,6 +1,8 @@
 # Rivers V1 Administration — Operations Spec
 
-**Rivers v0.50.1**
+**Rivers v0.54.0**
+
+> **v0.54.0 operator notes:** cdylib driver plugins are disabled — all drivers are compiled into `riversd`. The `[plugins] dir` config is deprecated. Apps with unresolvable drivers are isolated and return 503 without crashing the bundle. Bundle validation now runs a 4-layer pipeline, both in `riverpackage validate` and at `riversd` startup. Prometheus metrics are now actually emitting data.
 
 ## Environment
 
@@ -167,23 +169,31 @@ rate_limit_per_minute = 300
 
 ---
 
-## Bundle Validation
+## Bundle Validation (v0.54.0)
 
-`riversctl validate <bundle_path>` runs 9 checks against a bundle directory or archive.
+Bundle validation is now performed by `riverpackage validate` using a 4-layer pipeline. `riversd` runs the same pipeline automatically at startup — invalid bundles are rejected before drivers are initialized.
 
-`riversctl validate --schema server|app|bundle` outputs the corresponding JSON Schema.
+```bash
+riverpackage validate <bundle_path>
+riverpackage validate <bundle_path> --format json
+riverpackage validate <bundle_path> --config /opt/rivers/config/riversd.toml
+```
 
-### Validation Checks
+### Pipeline layers
 
-1. View types — validates view type values are recognized
-2. Driver names — validates driver names match registered drivers
-3. Datasource refs — validates all datasource references resolve
-4. DataView refs — validates all DataView references resolve
-5. Invalidates targets — validates invalidation targets exist
-6. Duplicate names — detects duplicate DataView/View/datasource names
-7. Schema file existence — verifies all referenced schema files exist on disk
-8. Cross-app service refs — validates inter-app service references resolve within the bundle
-9. TOML parse error context — provides line/column context for TOML syntax errors
+1. **Structural** — TOML parse of bundle `manifest.toml`, per-app `manifest.toml`, `resources.toml`, `app.toml`. Reports line/column context for syntax errors.
+2. **Existence** — all referenced files (schemas, handler modules, libraries, SPA assets) exist on disk.
+3. **Cross-reference** — DataViews resolve to declared datasources, views resolve to DataViews, `invalidates` targets exist, cross-app service references resolve within the bundle, view types are recognized, driver names match the static driver registry, no duplicate names, no orphan schema files.
+4. **Syntax** — JSON schemas parse, TS/JS handler modules compile via an embedded V8 instance (requires `--config` so the engine can be located in dynamic builds).
+
+### Startup integration
+
+`riversd` runs the 4-layer pipeline on the configured `bundle_path` before loading drivers, opening the router, or binding the listener. A validation failure prints per-layer diagnostics and exits with non-zero status.
+
+### Output formats
+
+- `--format text` (default) — human-readable per-layer output.
+- `--format json` — machine-readable; each layer reports `{ "layer": "...", "passed": bool, "errors": [...] }`.
 
 ---
 
@@ -494,10 +504,35 @@ watch_path = "./app.toml"
 - Restart HTTP server
 - Rebind sockets
 - Re-initialize connection pools
-- Reload plugins
+- Reload drivers (all drivers are statically linked in v0.54.0)
 - Re-resolve LockBox credentials
 
 MUST: Pool changes require full restart.
+
+---
+
+## Prometheus Metrics (v0.54.0)
+
+Enable the built-in Prometheus exporter:
+
+```toml
+[metrics]
+enabled = true
+port    = 9091       # default
+```
+
+Scrape endpoint: `http://localhost:9091/metrics`.
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `rivers_http_requests_total` | counter | `method`, `status` |
+| `rivers_http_request_duration_ms` | histogram | `method` |
+| `rivers_active_connections` | gauge | — |
+| `rivers_engine_executions_total` | counter | `engine` (`v8` \| `dataview` \| `none`), `success` |
+| `rivers_engine_execution_duration_ms` | histogram | `engine` |
+| `rivers_loaded_apps` | gauge | — |
+
+Metrics are behind the `metrics` cargo feature, enabled by default in deployed builds. In v0.54.0 the metrics are now actually emitted — previously the feature scaffolding was present but no data flowed.
 
 ---
 
@@ -614,19 +649,42 @@ Resolution:
 2. Implement client-side backoff
 3. Use `rate_limit_strategy = "custom_header"` for API keys
 
-### Plugin Load Failures
+### Missing Driver / App Load Failures (v0.54.0)
 
-Check logs for:
+As of v0.54.0 cdylib driver plugins are disabled and all drivers are compiled into `riversd`. If an app declares a datasource with a driver that cannot be resolved, the app is isolated rather than aborting the whole bundle.
+
+Check the per-app log (`log/apps/<app>.log`) for:
+
+```
+WARN  rivers::app: AppLoadFailed
+  app             = "canary-nosql"
+  missing_drivers = ["mongodb", "elasticsearch"]
+  resources       = ["mongo_primary", "search_cluster"]
+```
+
+Requests to endpoints in the failed app return:
+
+```json
+{"code": 503, "message": "app 'canary-nosql' is unavailable — missing driver(s): mongodb, elasticsearch"}
+```
+
+Resolution:
+1. Check `log/apps/<app>.log` for `AppLoadFailed` details.
+2. If your `riversd.toml` still has `[plugins] dir = "..."`, remove it — the config key is deprecated in v0.54.0 and has no effect.
+3. Verify the driver name in `resources.toml` matches the static driver registry.
+4. Other apps in the same bundle continue serving traffic normally.
+
+### Legacy: Plugin Load Failures
+
+Prior to v0.54.0, dynamic plugin loading could fail with ABI version mismatches:
+
 ```
 ERROR rivers::plugin: PluginLoadFailed
   path   = "/var/rivers/plugins/neo4j.so"
   reason = "ABI version mismatch: expected 3, got 2"
 ```
 
-Resolution:
-1. Rebuild plugin against current Rivers SDK
-2. Verify plugin file permissions
-3. Check plugin path in config
+This path is no longer reachable in v0.54.0 — there are no cdylib plugins. Plugin ABI v2 (synchronous C-ABI) is planned to re-enable dynamic loading. See `docs/arch/rivers-plugin-abi-v2-spec.md`.
 
 ---
 


### PR DESCRIPTION
Updates all 7 guide files with v0.54.0 changes:

- cdylib plugin removal + `[plugins] dir` deprecation
- `just deploy` static default, `just deploy-dynamic` for dynamic
- 503 blocking for apps with missing drivers
- ctx.ddl() + Gate 3 whitelist for init handlers
- Per-view rate limiting + guard lifecycle hooks
- Prometheus metrics (actually emitting now)
- 4-layer bundle validation pipeline
- Test runner diagnostics (TIMEOUT/CONNREF/EMPTY/DEAD)
- docs/guide copied by cargo deploy

Files: installation.md, cli.md, admin.md, developer.md, rivers-app-development.md, rivers-v1-admin.md, quickstart.md