### PR TITLE
feat: MCP view type — JSON-RPC AI tool endpoint with full protocol support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,10 @@ The Rust runtime is implemented across a workspace of crates under `crates/`.
 - Build so things are reusable
 - Collapse complex things down to simple
 - Keep it simple
-
+- always make sure canary is working no failures it is our production. 
 ## GOAL
 
-understand the codebase
+pushing out feature
 
 ## Architecture
 

--- a/canary-bundle/canary-sql/app.toml
+++ b/canary-bundle/canary-sql/app.toml
@@ -850,3 +850,19 @@ type       = "codecomponent"
 language   = "javascript"
 module     = "libraries/handlers/query-param-tests.ts"
 entrypoint = "qpEmptyValue"
+
+# ── MCP View ──────────────────────────────────────────────
+
+[api.views.mcp]
+path      = "canary/sql/mcp"
+view_type = "Mcp"
+method    = "POST"
+auth      = "none"
+
+[api.views.mcp.handler]
+type = "none"
+
+[api.views.mcp.tools.pg_select]
+dataview    = "pg_select_all"
+description = "Select all contacts from PostgreSQL"
+hints       = { read_only = true }

--- a/canary-bundle/run-tests.sh
+++ b/canary-bundle/run-tests.sh
@@ -301,7 +301,45 @@ else
   printf "  SKIP %-40s (MySQL unreachable)\n" "INT-MYSQL-DDL"
 fi
 
+# ── MCP Tests ────────────────────────────────────────────────
+echo ""
+echo "  ── MCP ──"
 
+# Initialize
+MCP_INIT=$(curl -sf -X POST "$BASE/sql/canary/sql/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' 2>/dev/null) || MCP_INIT=""
+if echo "$MCP_INIT" | grep -q "rivers-mcp"; then
+  printf "  PASS %-40s\n" "mcp-initialize"
+  PASS=$((PASS+1))
+else
+  printf "  FAIL %-40s\n" "mcp-initialize"
+  FAIL=$((FAIL+1))
+fi
+
+# Tools list
+MCP_TOOLS=$(curl -sf -X POST "$BASE/sql/canary/sql/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' 2>/dev/null) || MCP_TOOLS=""
+if echo "$MCP_TOOLS" | grep -q "pg_select"; then
+  printf "  PASS %-40s\n" "mcp-tools-list"
+  PASS=$((PASS+1))
+else
+  printf "  FAIL %-40s\n" "mcp-tools-list"
+  FAIL=$((FAIL+1))
+fi
+
+# Method not found
+MCP_404=$(curl -sf -X POST "$BASE/sql/canary/sql/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"nonexistent","params":{}}' 2>/dev/null) || MCP_404=""
+if echo "$MCP_404" | grep -q "Method not found"; then
+  printf "  PASS %-40s\n" "mcp-method-not-found"
+  PASS=$((PASS+1))
+else
+  printf "  FAIL %-40s\n" "mcp-method-not-found"
+  FAIL=$((FAIL+1))
+fi
 
 # ── Query Parameter Tests ────────────────────────────────────
 echo ""

--- a/canary-bundle/run-tests.sh
+++ b/canary-bundle/run-tests.sh
@@ -341,6 +341,18 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# Tools call
+MCP_CALL=$(curl -sf -X POST "$BASE/sql/canary/sql/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"pg_select","arguments":{}}}' 2>/dev/null) || MCP_CALL=""
+if echo "$MCP_CALL" | grep -q '"content"'; then
+  printf "  PASS %-40s\n" "mcp-tools-call"
+  PASS=$((PASS+1))
+else
+  printf "  FAIL %-40s\n" "mcp-tools-call"
+  FAIL=$((FAIL+1))
+fi
+
 # ── Query Parameter Tests ────────────────────────────────────
 echo ""
 echo "  ── Query Parameters ──"

--- a/crates/rivers-runtime/src/validate_crossref.rs
+++ b/crates/rivers-runtime/src/validate_crossref.rs
@@ -184,6 +184,69 @@ pub fn validate_crossref(bundle: &LoadedBundle) -> Vec<ValidationResult> {
                     }
                 }
 
+                // VAL-6: Prompt template placeholders must match argument declarations (MCP-12)
+                // MCP-13: Declared arguments should appear as placeholders (warning)
+                for (prompt_name, prompt_config) in &view_config.prompts {
+                    if prompt_config.template.is_empty() {
+                        continue;
+                    }
+                    let full_path = app.app_dir.join(&prompt_config.template);
+                    if let Ok(content) = std::fs::read_to_string(&full_path) {
+                        // Extract {placeholder} patterns from template
+                        let mut placeholders: Vec<String> = Vec::new();
+                        let mut chars = content.chars().peekable();
+                        while let Some(ch) = chars.next() {
+                            if ch == '{' {
+                                let mut name = String::new();
+                                for inner in chars.by_ref() {
+                                    if inner == '}' {
+                                        break;
+                                    }
+                                    name.push(inner);
+                                }
+                                if !name.is_empty() && !name.contains(' ') {
+                                    placeholders.push(name);
+                                }
+                            }
+                        }
+                        placeholders.dedup();
+
+                        let declared_args: Vec<&str> = prompt_config.arguments
+                            .iter()
+                            .map(|a| a.name.as_str())
+                            .collect();
+
+                        // VAL-6 (MCP-12): Placeholder without matching argument → error
+                        for placeholder in &placeholders {
+                            if !declared_args.contains(&placeholder.as_str()) {
+                                results.push(ValidationResult::fail(
+                                    "MCP-VAL-6",
+                                    &format!("{}/app.toml", app.manifest.app_name),
+                                    format!(
+                                        "MCP prompt '{}' template has placeholder '{{{}}}' with no matching argument declaration",
+                                        prompt_name, placeholder
+                                    ),
+                                ));
+                            }
+                        }
+
+                        // MCP-13: Declared argument without matching placeholder → warning
+                        for arg_name in &declared_args {
+                            if !placeholders.iter().any(|p| p == *arg_name) {
+                                let mut result = ValidationResult::warn(
+                                    "MCP-VAL-13",
+                                    format!(
+                                        "MCP prompt '{}' declares argument '{}' but template has no matching {{{}}} placeholder",
+                                        prompt_name, arg_name, arg_name
+                                    ),
+                                );
+                                result.file = Some(format!("{}/app.toml", app.manifest.app_name));
+                                results.push(result);
+                            }
+                        }
+                    }
+                }
+
                 // VAL-8: Unique tool names (handled by HashMap — keys are unique by definition)
                 // VAL-9: Unique resource names (same)
                 // VAL-10: Unique prompt names (same)

--- a/crates/rivers-runtime/src/validate_crossref.rs
+++ b/crates/rivers-runtime/src/validate_crossref.rs
@@ -117,6 +117,80 @@ pub fn validate_crossref(bundle: &LoadedBundle) -> Vec<ValidationResult> {
 
         // QP: Parameter mapping validation
         check_parameter_mappings(app, &mut results);
+
+        // ── MCP Validation (rivers-mcp-view-spec §12) ──────────────
+        {
+            let mcp_views: Vec<(&str, &crate::view::ApiViewConfig)> = app.config.api.views.iter()
+                .filter(|(_, v)| v.view_type == "Mcp")
+                .map(|(name, v)| (name.as_str(), v))
+                .collect();
+
+            // VAL-7: Only one MCP view per app
+            if mcp_views.len() > 1 {
+                let names: Vec<&str> = mcp_views.iter().map(|(n, _)| *n).collect();
+                results.push(ValidationResult::fail(
+                    "MCP-VAL-7",
+                    &format!("{}/app.toml", app.manifest.app_name),
+                    format!("only one MCP view allowed per app, found {}: {}", names.len(), names.join(", ")),
+                ));
+            }
+
+            for (view_name, view_config) in &mcp_views {
+                // VAL-1: Tool DataView references
+                for (tool_name, tool_config) in &view_config.tools {
+                    if !app.config.data.dataviews.contains_key(&tool_config.dataview) {
+                        results.push(ValidationResult::fail(
+                            "MCP-VAL-1",
+                            &format!("{}/app.toml", app.manifest.app_name),
+                            format!("MCP tool '{}' references undeclared DataView '{}'", tool_name, tool_config.dataview),
+                        ));
+                    }
+                }
+
+                // VAL-2: Resource DataView references
+                for (resource_name, resource_config) in &view_config.resources {
+                    if !app.config.data.dataviews.contains_key(&resource_config.dataview) {
+                        results.push(ValidationResult::fail(
+                            "MCP-VAL-2",
+                            &format!("{}/app.toml", app.manifest.app_name),
+                            format!("MCP resource '{}' references undeclared DataView '{}'", resource_name, resource_config.dataview),
+                        ));
+                    }
+                }
+
+                // VAL-4: Instructions file exists
+                if let Some(ref instructions_path) = view_config.instructions {
+                    let full_path = app.app_dir.join(instructions_path);
+                    if !full_path.exists() {
+                        results.push(ValidationResult::fail(
+                            "MCP-VAL-4",
+                            &format!("{}/app.toml", app.manifest.app_name),
+                            format!("MCP instructions file '{}' not found", instructions_path),
+                        ));
+                    }
+                }
+
+                // VAL-5: Prompt template files exist
+                for (prompt_name, prompt_config) in &view_config.prompts {
+                    if !prompt_config.template.is_empty() {
+                        let full_path = app.app_dir.join(&prompt_config.template);
+                        if !full_path.exists() {
+                            results.push(ValidationResult::fail(
+                                "MCP-VAL-5",
+                                &format!("{}/app.toml", app.manifest.app_name),
+                                format!("MCP prompt '{}' template '{}' not found", prompt_name, prompt_config.template),
+                            ));
+                        }
+                    }
+                }
+
+                // VAL-8: Unique tool names (handled by HashMap — keys are unique by definition)
+                // VAL-9: Unique resource names (same)
+                // VAL-10: Unique prompt names (same)
+                // These are enforced by the TOML parsing — duplicate table keys are a parse error.
+                let _ = view_name; // suppress unused warning
+            }
+        }
     }
 
     results
@@ -923,6 +997,11 @@ mod tests {
             on_stream: None,
             ws_hooks: None,
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         }
     }
 
@@ -960,6 +1039,11 @@ mod tests {
             on_stream: None,
             ws_hooks: None,
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         }
     }
 
@@ -992,6 +1076,11 @@ mod tests {
             on_stream: None,
             ws_hooks: None,
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         }
     }
 

--- a/crates/rivers-runtime/src/validate_existence.rs
+++ b/crates/rivers-runtime/src/validate_existence.rs
@@ -439,6 +439,7 @@ mod tests {
     use crate::loader::{LoadedApp, LoadedBundle};
     use crate::validate_result::ValidationStatus;
     use crate::view::{ApiViewConfig, HandlerConfig, HandlerStageConfig, OnStreamConfig, ViewEventHandlers, WebSocketHooks};
+    use std::collections::HashMap;
     use std::fs;
     use tempfile::TempDir;
 
@@ -615,6 +616,11 @@ nopassword = true
                 on_stream: None,
                 ws_hooks: None,
                 on_event: None,
+                tools: HashMap::new(),
+                resources: HashMap::new(),
+                prompts: HashMap::new(),
+                instructions: None,
+                session: None,
             },
         );
     }
@@ -1093,6 +1099,11 @@ nopassword = true
             on_stream: None,
             ws_hooks: None,
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         };
         bundle.apps[0]
             .config
@@ -1156,6 +1167,11 @@ nopassword = true
             }),
             ws_hooks: None,
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         };
         bundle.apps[0]
             .config
@@ -1230,6 +1246,11 @@ nopassword = true
                 on_disconnect: None,
             }),
             on_event: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         };
         bundle.apps[0]
             .config

--- a/crates/rivers-runtime/src/validate_structural.rs
+++ b/crates/rivers-runtime/src/validate_structural.rs
@@ -100,6 +100,7 @@ const VIEW_FIELDS: &[&str] = &[
     "sse_trigger_events", "sse_event_buffer_size",
     "session_revalidation_interval_s", "polling", "event_handlers",
     "on_stream", "ws_hooks", "on_event",
+    "tools", "resources", "prompts", "instructions", "session",
 ];
 const VIEW_REQUIRED: &[&str] = &["path", "method", "view_type", "handler"];
 

--- a/crates/rivers-runtime/src/view.rs
+++ b/crates/rivers-runtime/src/view.rs
@@ -113,6 +113,28 @@ pub struct ApiViewConfig {
 
     /// Event handler for MessageConsumer views.
     pub on_event: Option<OnEventConfig>,
+
+    // ── MCP fields ───────────────────────────────────────────────────
+
+    /// MCP tool declarations — whitelisted DataViews exposed as MCP tools.
+    #[serde(default)]
+    pub tools: HashMap<String, McpToolConfig>,
+
+    /// MCP resource declarations — read-only DataViews exposed as MCP resources.
+    #[serde(default)]
+    pub resources: HashMap<String, McpResourceConfig>,
+
+    /// MCP prompt declarations — markdown templates for AI workflows.
+    #[serde(default)]
+    pub prompts: HashMap<String, McpPromptConfig>,
+
+    /// Path to static instructions markdown file (relative to app root).
+    #[serde(default)]
+    pub instructions: Option<String>,
+
+    /// MCP session configuration.
+    #[serde(default)]
+    pub session: Option<McpSessionConfig>,
 }
 
 /// Guard lifecycle hooks — all optional, all side-effects only.
@@ -307,6 +329,8 @@ fn default_diff_strategy() -> String {
     "hash".to_string()
 }
 
+fn default_true() -> bool { true }
+
 /// `on_change` handler — invoked when polled data changes.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct OnChangeConfig {
@@ -324,3 +348,110 @@ pub struct ChangeDetectConfig {
     /// Function name within the module.
     pub entrypoint: String,
 }
+
+// ── MCP Config Types ─────────────────────────────────────
+
+/// MCP tool declaration — maps a DataView to an MCP tool.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpToolConfig {
+    /// Target DataView name.
+    pub dataview: String,
+    /// Human-readable description for the AI model.
+    #[serde(default)]
+    pub description: String,
+    /// HTTP method (GET/POST/PUT/DELETE) when DataView supports multiple.
+    #[serde(default)]
+    pub method: Option<String>,
+    /// Tool behavior hints for the AI model.
+    #[serde(default)]
+    pub hints: McpToolHints,
+}
+
+/// MCP tool behavior hints.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct McpToolHints {
+    /// Tool does not modify state.
+    #[serde(default)]
+    pub read_only: bool,
+    /// Tool may perform destructive operations.
+    #[serde(default = "default_true")]
+    pub destructive: bool,
+    /// Safe to retry without side effects.
+    #[serde(default)]
+    pub idempotent: bool,
+    /// Tool interacts with external systems.
+    #[serde(default = "default_true")]
+    pub open_world: bool,
+}
+
+impl Default for McpToolHints {
+    fn default() -> Self {
+        Self {
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+            open_world: true,
+        }
+    }
+}
+
+/// MCP resource declaration — read-only DataView exposure.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpResourceConfig {
+    /// Target DataView name (GET method only).
+    pub dataview: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// MIME type for the resource. Default: "application/json".
+    #[serde(default = "default_mime")]
+    pub mime_type: String,
+}
+
+fn default_mime() -> String { "application/json".into() }
+
+/// MCP prompt declaration — markdown template with argument substitution.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpPromptConfig {
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Path to markdown template file (relative to app bundle root).
+    #[serde(default)]
+    pub template: String,
+    /// Prompt arguments for template substitution.
+    #[serde(default)]
+    pub arguments: Vec<McpPromptArgument>,
+}
+
+/// A single prompt argument.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpPromptArgument {
+    /// Argument name (matches {placeholder} in template).
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Whether this argument is required.
+    #[serde(default)]
+    pub required: bool,
+    /// Default value when not provided.
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
+/// MCP session configuration.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct McpSessionConfig {
+    /// Session TTL in seconds. Default: 3600 (1 hour).
+    #[serde(default = "default_mcp_ttl")]
+    pub ttl_seconds: u64,
+}
+
+impl Default for McpSessionConfig {
+    fn default() -> Self {
+        Self { ttl_seconds: 3600 }
+    }
+}
+
+fn default_mcp_ttl() -> u64 { 3600 }

--- a/crates/riversd/src/bundle_diff.rs
+++ b/crates/riversd/src/bundle_diff.rs
@@ -311,6 +311,11 @@ mod tests {
                 on_stream: None,
                 ws_hooks: None,
                 on_event: None,
+                tools: HashMap::new(),
+                resources: HashMap::new(),
+                prompts: HashMap::new(),
+                instructions: None,
+                session: None,
             });
         }
 

--- a/crates/riversd/src/lib.rs
+++ b/crates/riversd/src/lib.rs
@@ -44,3 +44,5 @@ pub mod task_enrichment;
 pub mod transaction;
 pub mod view_engine;
 pub mod websocket;
+/// MCP view type — JSON-RPC dispatcher for AI tool access.
+pub mod mcp;

--- a/crates/riversd/src/mcp/dispatch.rs
+++ b/crates/riversd/src/mcp/dispatch.rs
@@ -1,0 +1,409 @@
+//! MCP JSON-RPC method dispatcher.
+
+use std::collections::HashMap;
+
+use std::sync::Arc;
+
+use rivers_runtime::view::{McpToolConfig, McpResourceConfig, McpPromptConfig};
+use rivers_runtime::rivers_driver_sdk::QueryValue;
+use rivers_runtime::DataViewExecutor;
+
+use super::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+use crate::server::AppContext;
+
+/// Dispatch a JSON-RPC request to the appropriate MCP handler.
+pub async fn dispatch(
+    ctx: &AppContext,
+    req: &JsonRpcRequest,
+    tools: &HashMap<String, McpToolConfig>,
+    resources: &HashMap<String, McpResourceConfig>,
+    prompts: &HashMap<String, McpPromptConfig>,
+    app_id: &str,
+    dv_namespace: &str,
+    app_dir: &std::path::Path,
+    instructions: Option<&str>,
+) -> JsonRpcResponse {
+    if req.jsonrpc != "2.0" {
+        return JsonRpcResponse::invalid_request(req.id.clone());
+    }
+
+    match req.method.as_str() {
+        "initialize" => handle_initialize(req, tools, resources, prompts, ctx, app_dir, instructions, dv_namespace).await,
+        "ping" => JsonRpcResponse::success(req.id.clone(), serde_json::json!({})),
+        "tools/list" => handle_tools_list(req, tools, ctx, dv_namespace).await,
+        "tools/call" => handle_tools_call(req, tools, ctx, dv_namespace).await,
+        "resources/list" => handle_resources_list(req, resources),
+        "resources/read" => handle_resources_read(req, resources, ctx, dv_namespace).await,
+        "resources/templates/list" => handle_resource_templates(req, resources, app_id),
+        "prompts/list" => handle_prompts_list(req, prompts),
+        "prompts/get" => handle_prompts_get(req, prompts, app_dir),
+        _ => JsonRpcResponse::method_not_found(req.id.clone(), &req.method),
+    }
+}
+
+async fn handle_initialize(
+    req: &JsonRpcRequest,
+    tools: &HashMap<String, McpToolConfig>,
+    resources: &HashMap<String, McpResourceConfig>,
+    prompts: &HashMap<String, McpPromptConfig>,
+    ctx: &AppContext,
+    app_dir: &std::path::Path,
+    static_instructions: Option<&str>,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let mut capabilities = serde_json::json!({
+        "tools": { "listChanged": false },
+    });
+    if !resources.is_empty() {
+        capabilities["resources"] = serde_json::json!({});
+    }
+    if !prompts.is_empty() {
+        capabilities["prompts"] = serde_json::json!({});
+    }
+
+    // Compile instructions: static file + auto-generated catalog
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor_opt = dv_guard.as_ref();
+    let ns = dv_namespace.to_string();
+    let get_params = |dv_name: &str, method: &str| -> Vec<rivers_runtime::DataViewParameterConfig> {
+        let namespaced = format!("{}:{}", ns, dv_name);
+        executor_opt
+            .and_then(|e| e.get_dataview_config(&namespaced))
+            .map(|cfg| cfg.parameters_for_method(method).to_vec())
+            .unwrap_or_default()
+    };
+
+    let instructions_doc = crate::mcp::instructions::compile_instructions(
+        static_instructions,
+        app_dir,
+        tools,
+        resources,
+        prompts,
+        &get_params,
+    );
+
+    let mut result = serde_json::json!({
+        "protocolVersion": "2024-11-05",
+        "serverInfo": {
+            "name": "rivers-mcp",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "capabilities": capabilities,
+    });
+
+    if !instructions_doc.is_empty() {
+        result["instructions"] = serde_json::Value::String(instructions_doc);
+    }
+
+    JsonRpcResponse::success(req.id.clone(), result)
+}
+
+async fn handle_tools_list(
+    req: &JsonRpcRequest,
+    tools: &HashMap<String, McpToolConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor: &Arc<DataViewExecutor> = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    let tool_list: Vec<serde_json::Value> = tools.iter().map(|(name, config)| {
+        let namespaced = format!("{}:{}", dv_namespace, config.dataview);
+        let method = config.method.as_deref().unwrap_or("GET");
+        let schema = if let Some(dv_config) = executor.get_dataview_config(&namespaced) {
+            let params = dv_config.parameters_for_method(method);
+            project_input_schema(params)
+        } else {
+            serde_json::json!({"type": "object", "properties": {}})
+        };
+
+        serde_json::json!({
+            "name": name,
+            "description": config.description,
+            "inputSchema": schema,
+            "annotations": {
+                "readOnlyHint": config.hints.read_only,
+                "destructiveHint": config.hints.destructive,
+                "idempotentHint": config.hints.idempotent,
+                "openWorldHint": config.hints.open_world,
+            }
+        })
+    }).collect();
+
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "tools": tool_list }))
+}
+
+async fn handle_tools_call(
+    req: &JsonRpcRequest,
+    tools: &HashMap<String, McpToolConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let tool_name = match req.params.get("name").and_then(|n| n.as_str()) {
+        Some(n) => n,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'name' in params"),
+    };
+
+    let tool_config = match tools.get(tool_name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(
+            req.id.clone(),
+            format!("Unknown tool: {}", tool_name),
+        ),
+    };
+
+    let arguments = req.params.get("arguments")
+        .and_then(|a| a.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let params: HashMap<String, QueryValue> = arguments.into_iter().map(|(k, v)| {
+        let qv = crate::view_engine::json_value_to_query_value(&v);
+        (k, qv)
+    }).collect();
+
+    let method = tool_config.method.as_deref().unwrap_or("GET");
+    let namespaced = format!("{}:{}", dv_namespace, tool_config.dataview);
+    let trace_id = uuid::Uuid::new_v4().to_string();
+
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor: &Arc<DataViewExecutor> = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    // Check if DataView supports streaming.
+    // TODO: when the streaming DataView execution path supports it, switch to SSE response here.
+    let is_streaming = executor.get_dataview_config(&namespaced)
+        .map(|dv| dv.streaming)
+        .unwrap_or(false);
+
+    if is_streaming {
+        tracing::debug!(tool = %tool_name, "streaming DataView detected — executing synchronously (SSE streaming deferred)");
+    }
+
+    match executor.execute(&namespaced, params, method, &trace_id, None).await {
+        Ok(response) => {
+            let text = serde_json::to_string(&response.query_result.rows).unwrap_or_default();
+            JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+                "content": [{ "type": "text", "text": text }]
+            }))
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            // Map DataView errors to JSON-RPC codes
+            if msg.contains("not found") || msg.contains("NotFound") {
+                JsonRpcResponse::invalid_params(req.id.clone(), format!("Unknown tool: {}", tool_name))
+            } else if msg.contains("Missing") || msg.contains("validation") {
+                JsonRpcResponse::invalid_params(req.id.clone(), msg)
+            } else {
+                JsonRpcResponse::server_error(req.id.clone(), msg)
+            }
+        }
+    }
+}
+
+fn handle_resources_list(
+    req: &JsonRpcRequest,
+    resources: &HashMap<String, McpResourceConfig>,
+) -> JsonRpcResponse {
+    let list: Vec<serde_json::Value> = resources.iter().map(|(name, config)| {
+        serde_json::json!({
+            "name": name,
+            "uri": format!("rivers://app/{}", name),
+            "description": config.description,
+            "mimeType": config.mime_type,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "resources": list }))
+}
+
+async fn handle_resources_read(
+    req: &JsonRpcRequest,
+    resources: &HashMap<String, McpResourceConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let uri = match req.params.get("uri").and_then(|u| u.as_str()) {
+        Some(u) => u,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'uri' in params"),
+    };
+
+    let resource_name = uri.rsplit('/').next().unwrap_or(uri);
+    let config = match resources.get(resource_name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(
+            req.id.clone(),
+            format!("Unknown resource: {}", resource_name),
+        ),
+    };
+
+    let namespaced = format!("{}:{}", dv_namespace, config.dataview);
+    let trace_id = uuid::Uuid::new_v4().to_string();
+
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor: &Arc<DataViewExecutor> = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    match executor.execute(&namespaced, HashMap::new(), "GET", &trace_id, None).await {
+        Ok(response) => {
+            let text = serde_json::to_string(&response.query_result.rows).unwrap_or_default();
+            JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": config.mime_type,
+                    "text": text,
+                }]
+            }))
+        }
+        Err(e) => JsonRpcResponse::server_error(req.id.clone(), e.to_string()),
+    }
+}
+
+fn handle_resource_templates(
+    req: &JsonRpcRequest,
+    resources: &HashMap<String, McpResourceConfig>,
+    app_id: &str,
+) -> JsonRpcResponse {
+    let templates: Vec<serde_json::Value> = resources.iter().map(|(name, config)| {
+        serde_json::json!({
+            "uriTemplate": format!("rivers://{}/{}", app_id, name),
+            "name": name,
+            "description": config.description,
+            "mimeType": config.mime_type,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "resourceTemplates": templates }))
+}
+
+fn handle_prompts_list(
+    req: &JsonRpcRequest,
+    prompts: &HashMap<String, McpPromptConfig>,
+) -> JsonRpcResponse {
+    let list: Vec<serde_json::Value> = prompts.iter().map(|(name, config)| {
+        let args: Vec<serde_json::Value> = config.arguments.iter().map(|a| {
+            serde_json::json!({
+                "name": a.name,
+                "description": a.description,
+                "required": a.required,
+            })
+        }).collect();
+        serde_json::json!({
+            "name": name,
+            "description": config.description,
+            "arguments": args,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "prompts": list }))
+}
+
+fn handle_prompts_get(
+    req: &JsonRpcRequest,
+    prompts: &HashMap<String, McpPromptConfig>,
+    app_dir: &std::path::Path,
+) -> JsonRpcResponse {
+    let name = match req.params.get("name").and_then(|n| n.as_str()) {
+        Some(n) => n,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'name'"),
+    };
+    let config = match prompts.get(name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(
+            req.id.clone(),
+            format!("Unknown prompt: {}", name),
+        ),
+    };
+
+    // Load template file
+    let template_path = app_dir.join(&config.template);
+    let template = match std::fs::read_to_string(&template_path) {
+        Ok(t) => t,
+        Err(e) => return JsonRpcResponse::server_error(
+            req.id.clone(),
+            format!("Failed to read template '{}': {}", config.template, e),
+        ),
+    };
+
+    // Get arguments from request
+    let req_args = req.params.get("arguments")
+        .and_then(|a| a.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // Validate required arguments
+    for arg_def in &config.arguments {
+        if arg_def.required && !req_args.contains_key(&arg_def.name) {
+            return JsonRpcResponse::invalid_params(
+                req.id.clone(),
+                format!("Missing required prompt argument: {}", arg_def.name),
+            );
+        }
+    }
+
+    // Build substitution map (request values + defaults)
+    let mut subs: HashMap<String, String> = HashMap::new();
+    for arg_def in &config.arguments {
+        if let Some(val) = req_args.get(&arg_def.name).and_then(|v| v.as_str()) {
+            subs.insert(arg_def.name.clone(), val.to_string());
+        } else if let Some(ref default) = arg_def.default {
+            subs.insert(arg_def.name.clone(), default.clone());
+        }
+    }
+
+    // Substitute {placeholder} in template
+    let mut resolved = template;
+    for (key, value) in &subs {
+        resolved = resolved.replace(&format!("{{{}}}", key), value);
+    }
+
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+        "description": config.description,
+        "messages": [{
+            "role": "user",
+            "content": { "type": "text", "text": resolved }
+        }]
+    }))
+}
+
+/// Project DataView parameters into MCP JSON Schema inputSchema.
+pub fn project_input_schema(params: &[rivers_runtime::DataViewParameterConfig]) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for p in params {
+        let json_type = match p.param_type.as_str() {
+            "integer" => "integer",
+            "float" | "decimal" => "number",
+            "boolean" => "boolean",
+            "array" => "array",
+            _ => "string",
+        };
+
+        let mut prop = serde_json::json!({ "type": json_type });
+        if let Some(ref default) = p.default {
+            prop["default"] = default.clone();
+        }
+        match p.param_type.as_str() {
+            "uuid" => { prop["format"] = serde_json::json!("uuid"); }
+            "date" => { prop["format"] = serde_json::json!("date"); }
+            "email" => { prop["format"] = serde_json::json!("email"); }
+            _ => {}
+        }
+
+        properties.insert(p.name.clone(), prop);
+        if p.required {
+            required.push(serde_json::Value::String(p.name.clone()));
+        }
+    }
+
+    serde_json::json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    })
+}

--- a/crates/riversd/src/mcp/instructions.rs
+++ b/crates/riversd/src/mcp/instructions.rs
@@ -1,0 +1,151 @@
+//! MCP instructions compiler — assembles static + auto-generated documentation.
+
+use std::collections::HashMap;
+use rivers_runtime::view::{McpToolConfig, McpResourceConfig, McpPromptConfig};
+use rivers_runtime::dataview::DataViewParameterConfig;
+
+/// Compile the instructions document from static file + auto-generated catalog.
+pub fn compile_instructions(
+    static_file: Option<&str>,
+    app_dir: &std::path::Path,
+    tools: &HashMap<String, McpToolConfig>,
+    resources: &HashMap<String, McpResourceConfig>,
+    prompts: &HashMap<String, McpPromptConfig>,
+    get_params: &dyn Fn(&str, &str) -> Vec<DataViewParameterConfig>,
+) -> String {
+    let mut doc = String::new();
+
+    // Source 1: Static instructions file (if declared)
+    if let Some(path) = static_file {
+        let full_path = app_dir.join(path);
+        if let Ok(content) = std::fs::read_to_string(&full_path) {
+            doc.push_str(&content);
+            doc.push_str("\n\n---\n\n");
+        }
+    }
+
+    // Source 2: Auto-generated tool catalog
+    if !tools.is_empty() {
+        doc.push_str("## Tool Reference\n\n");
+        let mut tool_names: Vec<&String> = tools.keys().collect();
+        tool_names.sort();
+        for name in tool_names {
+            let config = &tools[name];
+            doc.push_str(&format!("### `{}`\n\n", name));
+            if !config.description.is_empty() {
+                doc.push_str(&format!("{}\n\n", config.description));
+            }
+
+            let method = config.method.as_deref().unwrap_or("GET");
+            let params = get_params(&config.dataview, method);
+            if !params.is_empty() {
+                doc.push_str("**Parameters:**\n\n");
+                doc.push_str("| Name | Type | Required | Default |\n");
+                doc.push_str("|------|------|----------|---------|\n");
+                for p in &params {
+                    let default = p.default.as_ref()
+                        .map(|d| d.to_string())
+                        .unwrap_or_else(|| "—".into());
+                    doc.push_str(&format!(
+                        "| `{}` | {} | {} | {} |\n",
+                        p.name, p.param_type,
+                        if p.required { "yes" } else { "no" },
+                        default,
+                    ));
+                }
+                doc.push('\n');
+            }
+
+            // Hints
+            let mut hints = Vec::new();
+            if config.hints.read_only { hints.push("read-only"); }
+            if config.hints.destructive { hints.push("destructive"); }
+            if config.hints.idempotent { hints.push("idempotent"); }
+            if !hints.is_empty() {
+                doc.push_str(&format!("*Hints: {}*\n\n", hints.join(", ")));
+            }
+        }
+    }
+
+    // Source 3: Auto-generated resource reference
+    if !resources.is_empty() {
+        doc.push_str("## Resource Reference\n\n");
+        let mut resource_names: Vec<&String> = resources.keys().collect();
+        resource_names.sort();
+        for name in resource_names {
+            let config = &resources[name];
+            doc.push_str(&format!("### `{}`\n\n", name));
+            if !config.description.is_empty() {
+                doc.push_str(&format!("{}\n\n", config.description));
+            }
+            doc.push_str(&format!("- MIME type: `{}`\n\n", config.mime_type));
+        }
+    }
+
+    // Source 4: Auto-generated prompt reference
+    if !prompts.is_empty() {
+        doc.push_str("## Prompt Reference\n\n");
+        let mut prompt_names: Vec<&String> = prompts.keys().collect();
+        prompt_names.sort();
+        for name in prompt_names {
+            let config = &prompts[name];
+            doc.push_str(&format!("### `{}`\n\n", name));
+            if !config.description.is_empty() {
+                doc.push_str(&format!("{}\n\n", config.description));
+            }
+            if !config.arguments.is_empty() {
+                doc.push_str("**Arguments:**\n\n");
+                for arg in &config.arguments {
+                    let req = if arg.required { " (required)" } else { "" };
+                    let def = arg.default.as_ref()
+                        .map(|d| format!(" [default: {}]", d))
+                        .unwrap_or_default();
+                    doc.push_str(&format!("- `{}`{}{}\n", arg.name, req, def));
+                }
+                doc.push('\n');
+            }
+        }
+    }
+
+    doc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rivers_runtime::view::McpToolHints;
+
+    #[test]
+    fn empty_instructions() {
+        let tools = HashMap::new();
+        let resources = HashMap::new();
+        let prompts = HashMap::new();
+        let doc = compile_instructions(
+            None, std::path::Path::new("."),
+            &tools, &resources, &prompts,
+            &|_, _| vec![],
+        );
+        assert!(doc.is_empty());
+    }
+
+    #[test]
+    fn tool_catalog_generated() {
+        let mut tools = HashMap::new();
+        tools.insert("search".into(), McpToolConfig {
+            dataview: "search_dv".into(),
+            description: "Search records".into(),
+            method: None,
+            hints: McpToolHints::default(),
+        });
+        let resources = HashMap::new();
+        let prompts = HashMap::new();
+        let doc = compile_instructions(
+            None, std::path::Path::new("."),
+            &tools, &resources, &prompts,
+            &|_, _| vec![],
+        );
+        assert!(doc.contains("## Tool Reference"));
+        assert!(doc.contains("### `search`"));
+        assert!(doc.contains("Search records"));
+    }
+}

--- a/crates/riversd/src/mcp/jsonrpc.rs
+++ b/crates/riversd/src/mcp/jsonrpc.rs
@@ -1,0 +1,88 @@
+//! JSON-RPC 2.0 types for MCP protocol.
+
+use serde::{Deserialize, Serialize};
+
+/// A JSON-RPC 2.0 request.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    /// Must be "2.0".
+    pub jsonrpc: String,
+    /// Request ID (null for notifications).
+    pub id: Option<serde_json::Value>,
+    /// Method name.
+    pub method: String,
+    /// Method parameters.
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    /// Always "2.0".
+    pub jsonrpc: &'static str,
+    /// Echoed request ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<serde_json::Value>,
+    /// Result (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Error (present on failure).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    /// Error code.
+    pub code: i32,
+    /// Error message.
+    pub message: String,
+    /// Optional additional data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponse {
+    /// Create a success response.
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self { jsonrpc: "2.0", id, result: Some(result), error: None }
+    }
+
+    /// Create an error response.
+    pub fn error(id: Option<serde_json::Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0", id, result: None,
+            error: Some(JsonRpcError { code, message: message.into(), data: None }),
+        }
+    }
+
+    /// -32700: Parse error.
+    pub fn parse_error() -> Self { Self::error(None, -32700, "Parse error") }
+
+    /// -32600: Invalid Request.
+    pub fn invalid_request(id: Option<serde_json::Value>) -> Self {
+        Self::error(id, -32600, "Invalid Request")
+    }
+
+    /// -32601: Method not found.
+    pub fn method_not_found(id: Option<serde_json::Value>, method: &str) -> Self {
+        Self::error(id, -32601, format!("Method not found: {}", method))
+    }
+
+    /// -32602: Invalid params.
+    pub fn invalid_params(id: Option<serde_json::Value>, detail: impl Into<String>) -> Self {
+        Self::error(id, -32602, detail)
+    }
+
+    /// -32001: Session required.
+    pub fn session_required(id: Option<serde_json::Value>) -> Self {
+        Self::error(id, -32001, "Session required")
+    }
+
+    /// -32000: Server error.
+    pub fn server_error(id: Option<serde_json::Value>, msg: impl Into<String>) -> Self {
+        Self::error(id, -32000, msg)
+    }
+}

--- a/crates/riversd/src/mcp/mod.rs
+++ b/crates/riversd/src/mcp/mod.rs
@@ -1,0 +1,6 @@
+//! MCP (Model Context Protocol) view type — JSON-RPC dispatcher for AI tool access.
+
+pub mod jsonrpc;
+pub mod dispatch;
+pub mod instructions;
+pub mod session;

--- a/crates/riversd/src/mcp/session.rs
+++ b/crates/riversd/src/mcp/session.rs
@@ -1,0 +1,43 @@
+//! MCP session management — Mcp-Session-Id lifecycle with StorageEngine.
+
+use rivers_runtime::rivers_core::storage::StorageEngine;
+use std::sync::Arc;
+
+const MCP_SESSION_NAMESPACE: &str = "mcp";
+
+/// Create a new MCP session and store it in StorageEngine.
+pub async fn create_session(
+    storage: &Arc<dyn StorageEngine>,
+    ttl_seconds: u64,
+) -> Result<String, String> {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let data = serde_json::json!({
+        "created_at": chrono::Utc::now().to_rfc3339(),
+    });
+    let value = serde_json::to_vec(&data)
+        .map_err(|e| format!("session serialize: {e}"))?;
+    let ttl_ms = Some(ttl_seconds * 1000);
+
+    storage.set(MCP_SESSION_NAMESPACE, &session_id, value, ttl_ms)
+        .await
+        .map_err(|e| format!("session create: {e}"))?;
+
+    Ok(session_id)
+}
+
+/// Validate an MCP session — returns true if valid, refreshes TTL (sliding expiration).
+pub async fn validate_session(
+    storage: &Arc<dyn StorageEngine>,
+    session_id: &str,
+    ttl_seconds: u64,
+) -> bool {
+    match storage.get(MCP_SESSION_NAMESPACE, session_id).await {
+        Ok(Some(data)) => {
+            // Refresh TTL (sliding expiration) by re-setting
+            let ttl_ms = Some(ttl_seconds * 1000);
+            let _ = storage.set(MCP_SESSION_NAMESPACE, session_id, data, ttl_ms).await;
+            true
+        }
+        _ => false,
+    }
+}

--- a/crates/riversd/src/server/view_dispatch.rs
+++ b/crates/riversd/src/server/view_dispatch.rs
@@ -160,6 +160,9 @@ async fn view_dispatch_handler(
         "Websocket" => {
             return execute_ws_view(ctx, request, matched).await;
         }
+        "Mcp" => {
+            return execute_mcp_view(ctx, request, matched).await;
+        }
         _ => {
             // Rest (default) or streaming Rest — falls through to body extraction below
         }
@@ -430,6 +433,154 @@ async fn view_dispatch_handler(
         Err(e) => {
             error_response::map_view_error(&e, Some(&trace_id))
                 .into_axum_response()
+        }
+    }
+}
+
+/// Handle an MCP view — JSON-RPC 2.0 dispatch over HTTP POST.
+async fn execute_mcp_view(
+    ctx: AppContext,
+    request: axum::http::Request<axum::body::Body>,
+    matched: MatchedRoute,
+) -> axum::response::Response {
+    // Extract session header BEFORE consuming body (into_body() moves the request)
+    let session_id = request.headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // Read POST body (max 16 MiB)
+    let bytes = match axum::body::to_bytes(request.into_body(), 16 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            let resp = crate::mcp::jsonrpc::JsonRpcResponse::parse_error();
+            return axum::Json(resp).into_response();
+        }
+    };
+
+    // Parse JSON body
+    let body: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            let resp = crate::mcp::jsonrpc::JsonRpcResponse::parse_error();
+            return axum::Json(resp).into_response();
+        }
+    };
+
+    let tools = &matched.config.tools;
+    let resources = &matched.config.resources;
+    let prompts = &matched.config.prompts;
+    let instructions = matched.config.instructions.as_deref();
+    let app_id = &matched.app_id;
+    let dv_namespace = &matched.app_entry_point;
+
+    // Resolve app_dir from the loaded bundle using the app entry point slug
+    let app_dir_buf = ctx.loaded_bundle.as_ref()
+        .and_then(|b| b.apps.iter().find(|a| {
+            a.manifest.entry_point.as_deref() == Some(dv_namespace.as_str())
+                || a.manifest.app_entry_point.as_deref() == Some(dv_namespace.as_str())
+        }))
+        .map(|a| a.app_dir.clone())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let app_dir = app_dir_buf.as_path();
+
+    // Session TTL from config (default 3600s)
+    let session_ttl = matched.config.session
+        .as_ref()
+        .map(|s| s.ttl_seconds)
+        .unwrap_or(3600);
+
+    // Handle batch or single request
+    if let Some(batch) = body.as_array() {
+        let mut responses = Vec::new();
+        for item in batch {
+            match serde_json::from_value::<crate::mcp::jsonrpc::JsonRpcRequest>(item.clone()) {
+                Ok(req) => {
+                    if req.id.is_some() {
+                        // Session validation for non-initialize methods in batch
+                        if req.method != "initialize" && req.method != "ping" {
+                            if let Some(ref storage) = ctx.storage_engine {
+                                let valid = match &session_id {
+                                    Some(sid) => crate::mcp::session::validate_session(storage, sid, session_ttl).await,
+                                    None => false,
+                                };
+                                if !valid {
+                                    let resp = crate::mcp::jsonrpc::JsonRpcResponse::session_required(req.id.clone());
+                                    responses.push(serde_json::to_value(&resp).unwrap_or_default());
+                                    continue;
+                                }
+                            }
+                        }
+                        let resp = crate::mcp::dispatch::dispatch(
+                            &ctx, &req, tools, resources, prompts, app_id, dv_namespace, app_dir, instructions,
+                        ).await;
+                        responses.push(serde_json::to_value(&resp).unwrap_or_default());
+                    }
+                    // Notifications (no id) produce no response per JSON-RPC 2.0
+                }
+                Err(_) => {
+                    let resp = crate::mcp::jsonrpc::JsonRpcResponse::invalid_request(None);
+                    responses.push(serde_json::to_value(&resp).unwrap_or_default());
+                }
+            }
+        }
+        axum::Json(serde_json::Value::Array(responses)).into_response()
+    } else {
+        match serde_json::from_value::<crate::mcp::jsonrpc::JsonRpcRequest>(body) {
+            Ok(req) => {
+                if req.id.is_none() {
+                    // Notification — no response per JSON-RPC 2.0 spec
+                    return axum::http::StatusCode::NO_CONTENT.into_response();
+                }
+
+                // For non-initialize methods: validate session
+                if req.method != "initialize" && req.method != "ping" {
+                    if let Some(ref storage) = ctx.storage_engine {
+                        let valid = match &session_id {
+                            Some(sid) => crate::mcp::session::validate_session(storage, sid, session_ttl).await,
+                            None => false,
+                        };
+                        if !valid {
+                            let resp = crate::mcp::jsonrpc::JsonRpcResponse::session_required(req.id.clone());
+                            return axum::Json(resp).into_response();
+                        }
+                    }
+                }
+
+                let resp = crate::mcp::dispatch::dispatch(
+                    &ctx, &req, tools, resources, prompts, app_id, dv_namespace, app_dir, instructions,
+                ).await;
+
+                // For initialize: create session and attach Mcp-Session-Id header
+                if req.method == "initialize" {
+                    if let Some(ref storage) = ctx.storage_engine {
+                        match crate::mcp::session::create_session(storage, session_ttl).await {
+                            Ok(new_sid) => {
+                                let body_str = serde_json::to_string(&resp).unwrap_or_default();
+                                let mut response = axum::response::Response::builder()
+                                    .status(200)
+                                    .header("content-type", "application/json");
+                                if let Ok(hv) = axum::http::HeaderValue::from_str(&new_sid) {
+                                    response = response.header("mcp-session-id", hv);
+                                }
+                                return response
+                                    .body(axum::body::Body::from(body_str))
+                                    .unwrap_or_else(|_| axum::Json(resp).into_response());
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "failed to create MCP session");
+                                // Return response without session header rather than failing
+                            }
+                        }
+                    }
+                }
+
+                axum::Json(resp).into_response()
+            }
+            Err(_) => {
+                let resp = crate::mcp::jsonrpc::JsonRpcResponse::invalid_request(None);
+                axum::Json(resp).into_response()
+            }
         }
     }
 }

--- a/crates/riversd/src/view_engine/mod.rs
+++ b/crates/riversd/src/view_engine/mod.rs
@@ -67,6 +67,11 @@ mod tests {
             ws_hooks: None,
             on_event: None,
             polling: None,
+            tools: HashMap::new(),
+            resources: HashMap::new(),
+            prompts: HashMap::new(),
+            instructions: None,
+            session: None,
         }
     }
 

--- a/crates/riversd/tests/graphql_common/mod.rs
+++ b/crates/riversd/tests/graphql_common/mod.rs
@@ -43,5 +43,10 @@ pub fn default_view_config() -> ApiViewConfig {
         on_stream: None,
         ws_hooks: None,
         on_event: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }

--- a/crates/riversd/tests/guard_csrf_tests.rs
+++ b/crates/riversd/tests/guard_csrf_tests.rs
@@ -45,6 +45,11 @@ fn make_view(view_type: &str, guard: bool, auth: Option<&str>) -> ApiViewConfig 
         ws_hooks: None,
         on_event: None,
         polling: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }
 
@@ -79,6 +84,11 @@ fn make_dataview_view() -> ApiViewConfig {
         ws_hooks: None,
         on_event: None,
         polling: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }
 

--- a/crates/riversd/tests/message_consumer_tests.rs
+++ b/crates/riversd/tests/message_consumer_tests.rs
@@ -45,6 +45,11 @@ fn consumer_view(topic: &str, handler: &str) -> ApiViewConfig {
             handler_mode: None,
         }),
         polling: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }
 

--- a/crates/riversd/tests/view_engine_tests.rs
+++ b/crates/riversd/tests/view_engine_tests.rs
@@ -39,6 +39,11 @@ fn rest_view(method: &str, path: &str, dataview: &str) -> ApiViewConfig {
         ws_hooks: None,
         on_event: None,
         polling: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }
 
@@ -76,6 +81,11 @@ fn codecomponent_view(method: &str, path: &str) -> ApiViewConfig {
         ws_hooks: None,
         on_event: None,
         polling: None,
+        tools: HashMap::new(),
+        resources: HashMap::new(),
+        prompts: HashMap::new(),
+        instructions: None,
+        session: None,
     }
 }
 

--- a/docs/arch/rivers-mcp-view-spec.md
+++ b/docs/arch/rivers-mcp-view-spec.md
@@ -1,0 +1,866 @@
+# Rivers MCP View Type Specification
+
+**Document Type:** Spec Addition / Patch  
+**Scope:** MCP view type — JSON-RPC dispatch, tool/resource/prompt exposure, instructions, session management  
+**Status:** Design / Pre-Implementation  
+**Patches:** `rivers-view-layer-spec.md`, `rivers-processpool-runtime-spec-v2.md`, `rivers-httpd-spec.md`  
+**Depends On:** Epic 10 (DataView Engine), Epic 12 (ProcessPool), Epic 13 (View Layer), Epic 4 (EventBus), StorageEngine  
+**Protocol Target:** MCP Streamable HTTP — current stable specification at implementation time
+
+---
+
+## Table of Contents
+
+1. [Design Rationale](#1-design-rationale)
+2. [View Declaration](#2-view-declaration)
+3. [JSON-RPC Dispatch Layer](#3-json-rpc-dispatch-layer)
+4. [Tools](#4-tools)
+5. [Resources](#5-resources)
+6. [Prompts](#6-prompts)
+7. [Instructions](#7-instructions)
+8. [Streaming Tools](#8-streaming-tools)
+9. [Session Management](#9-session-management)
+10. [Parameter Resolution](#10-parameter-resolution)
+11. [Error Handling](#11-error-handling)
+12. [Validation Rules](#12-validation-rules)
+13. [Configuration Reference](#13-configuration-reference)
+14. [Examples](#14-examples)
+
+---
+
+## 1. Design Rationale
+
+### 1.1 Why a View Type
+
+A DataView is already an MCP tool. It has a name, typed input parameters (JSON Schema via `parameters`), typed output (via `get_schema`/`post_schema`), and a deterministic execution path. The MCP `tools/list` response is a projection of the DataView registry. `tools/call` is `dataview_engine.execute(name, params)` with a JSON-RPC envelope.
+
+The framework already does the hard part — parameter validation, schema enforcement, datasource dispatch, capability isolation. MCP is a wire protocol on top of the same execution engine.
+
+MCP Streamable HTTP is a single-endpoint protocol: the client POSTs JSON-RPC messages to one URL, receives either a JSON response or an SSE stream. This maps to a single Rivers view with a framework-level dispatcher — same architectural level as the REST, SSE, and WebSocket dispatchers.
+
+### 1.2 Ownership Boundary
+
+- **Framework MUST** — JSON-RPC parsing, method routing, session lifecycle, tool/resource/prompt schema generation, instructions compilation, parameter injection into DataView engine, streaming response mode switching.
+- **Developer MUST** — Whitelist which DataViews to expose, provide descriptions and hints, write prompt templates and instructions markdown.
+- **Framework MUST NOT** — expose DataViews not explicitly whitelisted, interpret tool results, inject MCP concerns into the DataView layer.
+
+### 1.3 Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Exposure model | Whitelist only | Explicit is safer; prevents accidental exposure of internal DataViews |
+| Descriptions | MCP config, not DataView | Different audience (AI model vs developer), different metadata; separation of concerns |
+| Prompts | Markdown templates with `{arg}` substitution | Same substitution engine as DataView path/body templating |
+| Instructions | Compiled tool catalog + optional static markdown file | Two-document agentic training pattern at the framework level |
+| Protocol version | Current stable at implementation time | MCP spec is still evolving; pinning risks staleness |
+| `notifications/tools/list_changed` | Deferred | Only relevant for hot reload in dev mode; production tool lists are static |
+
+---
+
+## 2. View Declaration
+
+```toml
+[api.views.mcp]
+path         = "/mcp"
+view_type    = "MCP"
+guard        = "api_key_guard"
+instructions = "docs/mcp-help.md"
+
+[api.views.mcp.tools.get_orders]
+dataview    = "get_orders"
+description = "Retrieve orders for a customer by ID or date range"
+hints       = { read_only = true }
+
+[api.views.mcp.tools.create_order]
+dataview    = "create_order"
+description = "Create a new order with line items and shipping address"
+hints       = { destructive = false, idempotent = false }
+
+[api.views.mcp.tools.cancel_order]
+dataview    = "cancel_order"
+description = "Cancel an existing order by order ID"
+hints       = { destructive = true, idempotent = true }
+
+[api.views.mcp.resources.product_catalog]
+dataview    = "get_products"
+description = "Browse the product catalog with optional category filter"
+
+[api.views.mcp.resources.inventory_status]
+dataview    = "get_inventory"
+description = "Check current inventory levels for a product"
+
+[api.views.mcp.prompts.fulfill_order]
+description = "Complete the order fulfillment workflow"
+template    = "prompts/fulfill_order.md"
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name     = "order_id"
+required = true
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name     = "priority"
+required = false
+default  = "normal"
+```
+
+### 2.1 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-1 | `view_type = "MCP"` activates the MCP JSON-RPC dispatcher. No other view type processes MCP traffic. |
+| MCP-2 | Only one MCP view per application. Multiple MCP views in the same app fail at config validation. |
+| MCP-3 | Every tool and resource MUST reference a DataView declared in `[data.dataviews.*]`. References to undeclared DataViews fail at config validation. |
+| MCP-4 | `instructions` path is relative to the app bundle root. File must exist at startup. Missing file fails at config validation. If omitted, only the auto-generated tool catalog is served. |
+| MCP-5 | `guard` is optional. If omitted, the MCP endpoint is unauthenticated. The guard follows the same contract as REST view guards. |
+
+---
+
+## 3. JSON-RPC Dispatch Layer
+
+The MCP dispatcher lives inside `riversd` at the view layer — not in a CodeComponent. It receives the raw POST body, parses the JSON-RPC 2.0 envelope, and routes by method.
+
+### 3.1 Method Routing
+
+| JSON-RPC Method | Rivers Internal Action |
+|---|---|
+| `initialize` | Negotiate capabilities, create MCP session in StorageEngine, return server info + instructions |
+| `ping` | Return empty result (session keepalive) |
+| `tools/list` | Project exposed DataViews into MCP tool schema format |
+| `tools/call` | Execute DataView via `dataview_engine.execute(name, params)` |
+| `resources/list` | Project exposed read-only DataViews into MCP resource format |
+| `resources/read` | Execute DataView (GET-only path) |
+| `resources/templates/list` | List parameterized resource URIs |
+| `prompts/list` | List declared prompt templates |
+| `prompts/get` | Resolve prompt template with argument substitution |
+
+### 3.2 Transport
+
+MCP Streamable HTTP transport. Single endpoint, POST method.
+
+- **Request:** `POST /mcp` with `Content-Type: application/json`, body is a JSON-RPC 2.0 message or batch.
+- **Response (non-streaming):** `Content-Type: application/json`, body is a JSON-RPC 2.0 response.
+- **Response (streaming):** `Content-Type: text/event-stream`, body is SSE with JSON-RPC response events.
+- **Session header:** `Mcp-Session-Id` sent by server on `initialize`, echoed by client on subsequent requests.
+
+### 3.3 Instructions Endpoint
+
+```
+GET /mcp/instructions
+```
+
+Returns the compiled instructions document as `text/markdown`. Same content the model receives during `initialize`. Available outside the JSON-RPC path for developer inspection, debugging, and integration with non-MCP AI systems.
+
+Compiled once on app startup. Re-compiled on hot reload in dev mode.
+
+### 3.4 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-6 | The dispatcher MUST reject JSON-RPC messages with `jsonrpc` != `"2.0"` with error code `-32600` (Invalid Request). |
+| MCP-7 | Unknown methods MUST return error code `-32601` (Method not found). |
+| MCP-8 | Malformed JSON MUST return error code `-32700` (Parse error). |
+| MCP-9 | Batch requests (JSON array of messages) MUST be supported. Responses are returned as a JSON array in the same order. |
+| MCP-10 | Notifications (requests without `id`) MUST NOT produce a response. |
+
+---
+
+## 4. Tools
+
+### 4.1 Schema Projection
+
+Each exposed tool's MCP schema is generated from the DataView's parameter declarations. The framework walks the DataView's `parameters` array and produces the MCP `inputSchema` (JSON Schema object).
+
+```
+DataView parameter declaration        →  MCP tool inputSchema property
+─────────────────────────────────────────────────────────────────────
+name = "user_id"                      →  "user_id": { ... }
+type = "uuid"                         →  "type": "string", "format": "uuid"
+required = true                       →  added to "required" array
+default = "active"                    →  "default": "active"
+```
+
+The `location` field (path, query, body, header) is NOT exposed to the model. The model sees a flat input schema. The DataView engine handles routing each parameter to its declared location internally.
+
+### 4.2 Tool Execution
+
+`tools/call` request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_orders",
+    "arguments": { "user_id": "42", "status": "active" }
+  }
+}
+```
+
+Execution path:
+1. Lookup tool name in MCP tool registry → resolve to DataView name
+2. Pass `arguments` as the DataView parameter map
+3. DataView engine validates parameters against declarations
+4. DataView engine routes each parameter to its declared `location` (path, query, body, header)
+5. DataView executes against datasource
+6. Result wrapped in JSON-RPC response
+
+The MCP dispatcher calls the same `dataview_engine.execute()` path as `ctx.dataview()`. If the DataView has a handler chain, those handlers run normally. MCP is an entry point, not a bypass.
+
+### 4.3 Full CRUD via Tools
+
+When a DataView declares multiple methods (GET/POST/PUT/DELETE via `get_query`, `post_query`, `put_query`, `delete_query`), the MCP exposure config determines how these map to tools.
+
+A single DataView with full CRUD can be exposed as:
+- One tool per method (explicit, fine-grained control)
+- A single tool where the method is inferred from the arguments (compact, but less discoverable)
+
+The recommended pattern is one tool per method:
+
+```toml
+[api.views.mcp.tools.get_order]
+dataview    = "orders"
+method      = "GET"
+description = "Retrieve an order by ID"
+hints       = { read_only = true }
+
+[api.views.mcp.tools.create_order]
+dataview    = "orders"
+method      = "POST"
+description = "Create a new order"
+hints       = { destructive = false, idempotent = false }
+
+[api.views.mcp.tools.update_order]
+dataview    = "orders"
+method      = "PUT"
+description = "Update an existing order"
+hints       = { destructive = false, idempotent = true }
+
+[api.views.mcp.tools.delete_order]
+dataview    = "orders"
+method      = "DELETE"
+description = "Delete an order"
+hints       = { destructive = true, idempotent = true }
+```
+
+When `method` is specified, only the parameters declared for that method (e.g., `get.parameters`, `post.parameters`) are projected into the tool's `inputSchema`. When `method` is omitted, all parameters across all methods are merged — this is valid only for single-method DataViews.
+
+### 4.4 Annotations
+
+MCP tool annotations provide hints to the model about tool behavior. Declared in the `hints` table:
+
+| Hint | Type | Default | Meaning |
+|---|---|---|---|
+| `read_only` | bool | false | Tool does not modify state |
+| `destructive` | bool | true | Tool may perform destructive operations |
+| `idempotent` | bool | false | Safe to retry without side effects |
+| `open_world` | bool | true | Tool interacts with external systems |
+
+When `method` is declared, the framework can infer defaults:
+- `method = "GET"` → `read_only = true`, `destructive = false`
+- `method = "DELETE"` → `destructive = true`
+
+Explicit hints override inferred defaults.
+
+---
+
+## 5. Resources
+
+MCP resources are read-only named data the model can fetch. These map to DataViews exposed with the resource contract.
+
+### 5.1 Resource Execution
+
+`resources/read` always executes the DataView's GET path. Write methods (POST/PUT/DELETE) are not available through the resource interface — they require tools.
+
+### 5.2 URI Scheme
+
+Resources use a `rivers://` URI scheme:
+
+```
+rivers://{app_id}/{resource_name}
+rivers://{app_id}/{resource_name}/{param_value}
+```
+
+For parameterized resources, the URI template is exposed via `resources/templates/list`:
+
+```
+rivers://{app_id}/inventory_status/{product_id}
+```
+
+### 5.3 MIME Types
+
+Resource responses include a MIME type. Default is `application/json`. Override with `mime_type` in the resource config:
+
+```toml
+[api.views.mcp.resources.product_catalog]
+dataview    = "get_products"
+description = "Full product catalog"
+mime_type   = "application/json"
+```
+
+---
+
+## 6. Prompts
+
+Server-provided workflow templates. The AI client discovers them via `prompts/list`, retrieves one via `prompts/get`, and uses the result as a structured instruction for accomplishing a task with the available tools.
+
+### 6.1 Template Format
+
+Prompt templates are markdown files with `{argument}` substitution placeholders. Same substitution syntax as DataView path and body templating.
+
+```markdown
+<!-- prompts/fulfill_order.md -->
+# Order Fulfillment Workflow
+
+Look up order **{order_id}** using `get_order`.
+
+Verify inventory for each line item using `check_inventory`.
+
+If all items are in stock, call `create_shipment` with priority **{priority}**.
+
+If any items are out of stock:
+1. Call `flag_backorder` for the out-of-stock items
+2. Call `create_shipment` for the in-stock items as a partial shipment
+3. Notify the customer using `send_notification` with the backorder details
+```
+
+### 6.2 Argument Substitution
+
+At `prompts/get` time, the framework:
+1. Reads the template file
+2. Validates all required arguments are present in the request
+3. Applies defaults for missing optional arguments
+4. Substitutes `{argument}` placeholders with values
+5. Returns the resolved markdown as the prompt content
+
+Unrecognized placeholders (no matching argument declaration) fail at config validation, not at runtime.
+
+### 6.3 Declaration
+
+```toml
+[api.views.mcp.prompts.fulfill_order]
+description = "Complete the order fulfillment workflow"
+template    = "prompts/fulfill_order.md"
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name        = "order_id"
+description = "The order ID to fulfill"
+required    = true
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name        = "priority"
+description = "Fulfillment priority level"
+required    = false
+default     = "normal"
+```
+
+### 6.4 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-11 | Template path is relative to app bundle root. Missing template file fails at config validation. |
+| MCP-12 | Every `{placeholder}` in the template MUST have a matching argument declaration. Orphans fail at config validation. |
+| MCP-13 | Every declared argument MUST appear as a `{placeholder}` in the template. Unused arguments fail at config validation with a warning (not an error). |
+
+---
+
+## 7. Instructions
+
+### 7.1 Compilation
+
+The instructions document is assembled from two sources:
+
+**Source 1 — Static instructions file.** Developer-authored markdown with business rules, usage patterns, example workflows, domain context. Declared via `instructions = "docs/mcp-help.md"` in the MCP view config.
+
+**Source 2 — Auto-generated tool catalog.** The framework walks every exposed tool, resource, and prompt, and renders a structured reference document including: tool name, description, parameter schemas (name, type, required, default), annotations/hints, resource URIs, and prompt names with argument lists.
+
+### 7.2 Assembly Order
+
+```
+1. Static help.md content (verbatim, if declared)
+2. ---
+3. ## Tool Reference (auto-generated)
+4.   - Tool entries with descriptions, parameters, hints
+5. ## Resource Reference (auto-generated)
+6.   - Resource entries with descriptions, URI templates
+7. ## Prompt Reference (auto-generated)
+8.   - Prompt entries with descriptions, arguments
+```
+
+Static file first — the developer's narrative context before the structured reference. If `instructions` is omitted, only the auto-generated sections are produced.
+
+### 7.3 Delivery
+
+- **MCP `initialize` response:** Instructions document included in the `instructions` field of the `ServerCapabilities` response.
+- **HTTP GET endpoint:** `GET /mcp/instructions` returns the same compiled document as `text/markdown`.
+
+Both paths read the same compiled output. Compiled once at app startup, re-compiled on hot reload in dev mode.
+
+### 7.4 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-14 | The auto-generated tool catalog MUST always be present, even if no static instructions file is declared. |
+| MCP-15 | The `GET /mcp/instructions` endpoint MUST NOT require MCP session authentication. It follows the same guard as the MCP view. |
+| MCP-16 | The compiled instructions MUST be regenerated on hot reload when any tool, resource, or prompt declaration changes. |
+
+---
+
+## 8. Streaming Tools
+
+### 8.1 Detection
+
+When `tools/call` targets a DataView with `streaming = true`, the MCP dispatcher automatically switches to SSE response mode. No special MCP-level configuration is required — the streaming property is on the DataView, not the tool exposure.
+
+### 8.2 Wire Format
+
+Streaming tool responses use the MCP Streamable HTTP SSE transport. Each chunk from the streaming DataView is wrapped in a JSON-RPC notification and sent as an SSE event:
+
+```
+data: {"jsonrpc":"2.0","method":"notifications/tools/progress","params":{"token":"...","data":{"token":"The"}}}\n\n
+data: {"jsonrpc":"2.0","method":"notifications/tools/progress","params":{"token":"...","data":{"token":" answer"}}}\n\n
+data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"complete"}]},"id":1}\n\n
+```
+
+The final event is the JSON-RPC response with the tool's result. Preceding events are progress notifications.
+
+### 8.3 Error Mid-Stream
+
+Same as Rivers streaming REST error handling: if the generator throws after the first yield, a poison chunk is emitted as the final SSE event, wrapped in a JSON-RPC error response:
+
+```
+data: {"jsonrpc":"2.0","error":{"code":-32000,"message":"upstream model API unavailable"},"id":1}\n\n
+```
+
+### 8.4 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-17 | Streaming detection is automatic. If the target DataView has `streaming = true`, the response MUST use SSE transport. |
+| MCP-18 | `stream_timeout_ms` from the DataView's streaming config applies. The MCP layer does not define its own timeout. |
+| MCP-19 | Non-streaming DataViews MUST always return a single JSON-RPC response, never SSE. |
+
+---
+
+## 9. Session Management
+
+### 9.1 Session Lifecycle
+
+MCP sessions use the `Mcp-Session-Id` header for continuity.
+
+1. Client sends `initialize` — no session header.
+2. Server creates a session entry in StorageEngine with TTL, returns `Mcp-Session-Id` in response header.
+3. Client echoes `Mcp-Session-Id` on all subsequent requests.
+4. Server validates session on each request. Invalid/expired session returns JSON-RPC error `-32001`.
+5. Session expires on TTL or explicit termination.
+
+### 9.2 StorageEngine Key
+
+```
+mcp:session:{session_id}
+```
+
+Session data stored:
+- `created_at` — ISO 8601 timestamp
+- `capabilities` — negotiated capability set from `initialize`
+- `identity` — guard-resolved identity (if guard is configured)
+
+### 9.3 Configuration
+
+```toml
+[api.views.mcp.session]
+ttl_seconds = 3600          # default: 3600 (1 hour)
+```
+
+### 9.4 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-20 | `initialize` MUST create a new session. Re-initializing with an existing session ID replaces the session. |
+| MCP-21 | Requests to any method other than `initialize` without a valid `Mcp-Session-Id` MUST return JSON-RPC error `-32001` with message "Session required". |
+| MCP-22 | Session TTL is reset on every valid request (sliding expiration). |
+
+---
+
+## 10. Parameter Resolution
+
+The MCP layer passes tool arguments as a flat JSON object to the DataView engine. The DataView engine routes each argument to its declared `location` — the MCP layer never interprets parameter locations.
+
+### 10.1 Resolution Flow
+
+```
+MCP tools/call arguments:    { "user_id": "42", "status": "active" }
+                                       │
+                                       ▼
+DataView parameter declarations:
+  user_id  → location = "path"    → substituted into path template
+  status   → location = "query"   → appended to query string
+                                       │
+                                       ▼
+Resolved HTTP request:           GET /v1/users/42/orders?status=active
+```
+
+### 10.2 Type Coercion
+
+MCP arguments arrive as JSON values. The DataView engine coerces them to match declared parameter types:
+
+| Declared type | JSON input | Coercion |
+|---|---|---|
+| `string` | `"42"` | No coercion needed |
+| `integer` | `42` | No coercion needed |
+| `integer` | `"42"` | Parse string → integer |
+| `uuid` | `"abc-123"` | Validated as UUID format |
+| `boolean` | `true` | No coercion needed |
+| `boolean` | `"true"` | Parse string → boolean |
+
+Coercion failure returns JSON-RPC error `-32602` (Invalid params).
+
+### 10.3 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-23 | Arguments not matching any declared parameter MUST be rejected with `-32602`. |
+| MCP-24 | Missing required parameters MUST be rejected with `-32602`. |
+| MCP-25 | Default values from parameter declarations apply when an optional argument is absent. |
+
+---
+
+## 11. Error Handling
+
+### 11.1 JSON-RPC Error Codes
+
+| Code | Meaning | When |
+|---|---|---|
+| `-32700` | Parse error | Malformed JSON body |
+| `-32600` | Invalid Request | Missing `jsonrpc: "2.0"`, missing `method` |
+| `-32601` | Method not found | Unknown JSON-RPC method |
+| `-32602` | Invalid params | Parameter validation failure, unknown tool/resource/prompt name |
+| `-32001` | Session required | Missing or invalid `Mcp-Session-Id` |
+| `-32000` | Server error | DataView execution failure, datasource errors |
+
+### 11.2 DataView Error Mapping
+
+DataView engine errors are mapped to JSON-RPC errors:
+
+| DataView Error | JSON-RPC Code | Message |
+|---|---|---|
+| Parameter validation failure | `-32602` | Validation details |
+| DataView not found | `-32602` | "Unknown tool: {name}" |
+| Datasource connection failure | `-32000` | "Datasource unavailable" |
+| Handler error (CodeComponent throw) | `-32000` | Handler error message |
+| Timeout | `-32000` | "Execution timeout" |
+
+### 11.3 Constraints
+
+| ID | Rule |
+|---|---|
+| MCP-26 | DataView errors MUST NOT leak datasource connection details, credentials, or internal stack traces. Error messages are sanitized before inclusion in JSON-RPC responses. |
+| MCP-27 | Guard authentication failures MUST return HTTP 401, not a JSON-RPC error. The guard runs before the JSON-RPC dispatcher. |
+
+---
+
+## 12. Validation Rules
+
+Config validation at app startup (fail-fast):
+
+| ID | Rule |
+|---|---|
+| VAL-1 | Every `tools.*.dataview` must reference a declared DataView. |
+| VAL-2 | Every `resources.*.dataview` must reference a declared DataView. |
+| VAL-3 | Every `tools.*.method` must match a method declared on the referenced DataView (GET/POST/PUT/DELETE). |
+| VAL-4 | `instructions` file path must exist in the bundle. |
+| VAL-5 | Every prompt `template` file path must exist in the bundle. |
+| VAL-6 | Every `{placeholder}` in a prompt template must have a matching argument declaration. |
+| VAL-7 | Only one `view_type = "MCP"` per application. |
+| VAL-8 | Tool names must be unique within the MCP view. |
+| VAL-9 | Resource names must be unique within the MCP view. |
+| VAL-10 | Prompt names must be unique within the MCP view. |
+
+---
+
+## 13. Configuration Reference
+
+### 13.1 MCP View
+
+```toml
+[api.views.mcp]
+path         = "/mcp"              # REQUIRED — endpoint path
+view_type    = "MCP"               # REQUIRED — activates MCP dispatcher
+guard        = "api_key_guard"     # optional — guard view name
+instructions = "docs/mcp-help.md"  # optional — static instructions file
+
+[api.views.mcp.session]
+ttl_seconds  = 3600                # default: 3600
+```
+
+### 13.2 Tool
+
+```toml
+[api.views.mcp.tools.{tool_name}]
+dataview    = "dataview_name"      # REQUIRED — DataView reference
+description = "..."                # REQUIRED — human-readable for AI model
+method      = "GET"                # optional — restrict to one HTTP method
+hints       = { ... }              # optional — MCP annotations
+```
+
+### 13.3 Resource
+
+```toml
+[api.views.mcp.resources.{resource_name}]
+dataview    = "dataview_name"      # REQUIRED — DataView reference
+description = "..."                # REQUIRED — human-readable for AI model
+mime_type   = "application/json"   # optional — default: application/json
+```
+
+### 13.4 Prompt
+
+```toml
+[api.views.mcp.prompts.{prompt_name}]
+description = "..."                # REQUIRED — human-readable for AI model
+template    = "prompts/file.md"    # REQUIRED — template file path
+
+[[api.views.mcp.prompts.{prompt_name}.arguments]]
+name        = "arg_name"           # REQUIRED
+description = "..."                # optional — shown to AI model
+required    = true                 # default: false
+default     = "value"              # optional — used when argument absent
+```
+
+---
+
+## 14. Examples
+
+### 14.1 Minimal MCP — Existing REST App
+
+Add MCP to an existing app with three DataViews. No CodeComponent changes needed.
+
+```toml
+# Existing DataViews (unchanged)
+[data.dataviews.get_contacts]
+datasource = "primary_db"
+query      = "SELECT id, name, email FROM contacts WHERE org_id = $org_id"
+[[data.dataviews.get_contacts.parameters]]
+name     = "org_id"
+type     = "uuid"
+required = true
+
+[data.dataviews.create_contact]
+datasource = "primary_db"
+post_query = "INSERT INTO contacts (name, email, org_id) VALUES ($name, $email, $org_id) RETURNING *"
+[[data.dataviews.create_contact.parameters]]
+name = "name"
+type = "string"
+required = true
+[[data.dataviews.create_contact.parameters]]
+name = "email"
+type = "string"
+required = true
+[[data.dataviews.create_contact.parameters]]
+name = "org_id"
+type = "uuid"
+required = true
+
+[data.dataviews.search_contacts]
+datasource = "primary_db"
+query      = "SELECT * FROM contacts WHERE name ILIKE '%' || $q || '%'"
+[[data.dataviews.search_contacts.parameters]]
+name = "q"
+type = "string"
+required = true
+
+# MCP exposure — this is the only addition
+[api.views.mcp]
+path      = "/mcp"
+view_type = "MCP"
+guard     = "api_key_guard"
+
+[api.views.mcp.tools.get_contacts]
+dataview    = "get_contacts"
+description = "List all contacts for an organization"
+hints       = { read_only = true }
+
+[api.views.mcp.tools.create_contact]
+dataview    = "create_contact"
+description = "Create a new contact with name and email"
+hints       = { destructive = false, idempotent = false }
+
+[api.views.mcp.tools.search_contacts]
+dataview    = "search_contacts"
+description = "Search contacts by name (partial match)"
+hints       = { read_only = true }
+```
+
+The AI model calls `tools/call` with `{"name": "search_contacts", "arguments": {"q": "smith"}}`. The MCP dispatcher passes `{"q": "smith"}` to the DataView engine. The engine binds `$q` in the SQL query. Results return through the JSON-RPC response. Same execution path as `GET /api/contacts?q=smith`.
+
+### 14.2 Full-Featured MCP — Order Management
+
+```toml
+[api.views.mcp]
+path         = "/mcp"
+view_type    = "MCP"
+guard        = "api_key_guard"
+instructions = "docs/order-api-help.md"
+
+# ── Tools ──
+
+[api.views.mcp.tools.get_order]
+dataview    = "orders"
+method      = "GET"
+description = "Retrieve an order by ID, returns order details with line items"
+hints       = { read_only = true }
+
+[api.views.mcp.tools.create_order]
+dataview    = "orders"
+method      = "POST"
+description = "Create a new order with customer ID, line items, and shipping address"
+hints       = { destructive = false, idempotent = false }
+
+[api.views.mcp.tools.update_order]
+dataview    = "orders"
+method      = "PUT"
+description = "Update order status or shipping details"
+hints       = { destructive = false, idempotent = true }
+
+[api.views.mcp.tools.cancel_order]
+dataview    = "orders"
+method      = "DELETE"
+description = "Cancel an order — only pending orders can be cancelled"
+hints       = { destructive = true, idempotent = true }
+
+[api.views.mcp.tools.check_inventory]
+dataview    = "inventory_check"
+description = "Check stock levels for a product by SKU"
+hints       = { read_only = true }
+
+# ── Resources ──
+
+[api.views.mcp.resources.product_catalog]
+dataview    = "get_products"
+description = "Full product catalog with pricing and availability"
+
+[api.views.mcp.resources.shipping_zones]
+dataview    = "get_shipping_zones"
+description = "Available shipping zones and delivery estimates"
+
+# ── Prompts ──
+
+[api.views.mcp.prompts.fulfill_order]
+description = "Step-by-step order fulfillment workflow"
+template    = "prompts/fulfill_order.md"
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name        = "order_id"
+description = "The order to fulfill"
+required    = true
+
+[[api.views.mcp.prompts.fulfill_order.arguments]]
+name        = "priority"
+description = "Fulfillment priority: normal, rush, overnight"
+required    = false
+default     = "normal"
+
+[api.views.mcp.session]
+ttl_seconds = 1800
+```
+
+### 14.3 Streaming MCP — LLM Proxy
+
+```toml
+[data.datasources.anthropic]
+driver      = "http"
+base_url    = "https://api.anthropic.com"
+protocol    = "http2"
+auth        = "bearer"
+credentials = "lockbox://anthropic/api_key"
+
+[data.dataviews.generate]
+datasource       = "anthropic"
+method           = "POST"
+path             = "/v1/messages"
+streaming        = true
+streaming_format = "sse"
+stream_timeout_ms = 120000
+
+[data.dataviews.generate.body_template]
+model      = "{model}"
+max_tokens = 1024
+stream     = true
+messages   = "{messages}"
+
+[[data.dataviews.generate.parameters]]
+name     = "model"
+location = "body"
+required = false
+default  = "claude-sonnet-4-20250514"
+
+[[data.dataviews.generate.parameters]]
+name     = "messages"
+location = "body"
+required = true
+
+# MCP exposure — streaming tool
+[api.views.mcp]
+path      = "/mcp"
+view_type = "MCP"
+guard     = "api_key_guard"
+
+[api.views.mcp.tools.generate]
+dataview    = "generate"
+description = "Generate text using Claude — returns a streaming response of tokens"
+hints       = { read_only = true, open_world = true }
+```
+
+The model calls `tools/call` with `{"name": "generate", "arguments": {"messages": [...]}}`. The MCP dispatcher detects `streaming = true` on the DataView and switches to SSE response mode automatically. Each chunk from the upstream Anthropic API is forwarded as an MCP progress notification.
+
+### 14.4 HTTP DataView with Query Parameters
+
+```toml
+[data.datasources.internal_api]
+driver   = "http"
+base_url = "https://api.internal.example.com"
+auth     = "bearer"
+credentials = "lockbox://internal/token"
+
+[data.dataviews.get_orders]
+datasource = "internal_api"
+method     = "GET"
+path       = "/v1/users/{user_id}/orders"
+
+[[data.dataviews.get_orders.parameters]]
+name     = "user_id"
+location = "path"
+required = true
+
+[[data.dataviews.get_orders.parameters]]
+name     = "status"
+location = "query"
+required = false
+default  = "active"
+
+[[data.dataviews.get_orders.parameters]]
+name     = "limit"
+location = "query"
+required = false
+default  = "50"
+
+# MCP tool
+[api.views.mcp.tools.get_orders]
+dataview    = "get_orders"
+description = "Get orders for a user, optionally filtered by status"
+hints       = { read_only = true }
+```
+
+The model sends: `{"user_id": "42", "status": "shipped", "limit": "10"}`. The DataView engine routes `user_id` to the path, `status` and `limit` to the query string. The model never knows the difference — it sees a flat input schema.
+
+---
+
+## Shaping Amendments
+
+None. Initial specification.
+
+---
+
+## CHANGELOG
+
+| Date | Change |
+|---|---|
+| 2026-04-15 | Initial specification — MCP View Type for Rivers v1 |

--- a/docs/guide/tutorials/tutorial-mcp.md
+++ b/docs/guide/tutorials/tutorial-mcp.md
@@ -1,0 +1,462 @@
+# Tutorial: MCP (Model Context Protocol)
+
+**Rivers v0.54.0**
+
+## Overview
+
+MCP (Model Context Protocol) exposes your DataViews as AI-consumable tools via JSON-RPC 2.0. By configuring an MCP view, you enable AI models (Claude, ChatGPT, etc.) to discover and call your data operations as first-class tools in their agentic workflows.
+
+MCP in Rivers includes three capabilities:
+
+- **Tools** — Whitelisted DataViews exposed as callable tools with descriptions, parameters, and AI hints
+- **Resources** — Read-only DataViews available as context data (markdown, JSON, etc.)
+- **Prompts** — Markdown templates with argument substitution for AI instruction workflows
+
+This tutorial covers adding an MCP view to your app, testing it with curl, and configuring tools, resources, and prompts.
+
+## Prerequisites
+
+- A running Rivers instance (see the [Getting Started tutorial](tutorial-getting-started.md))
+- A bundle with DataViews configured (or use the address-book bundle)
+- `curl` for testing MCP JSON-RPC calls
+
+---
+
+## Step 1: Add MCP to Your App
+
+Open your app's `app.toml` file and add an MCP view:
+
+```toml
+[api.views.mcp]
+path      = "/mcp"
+view_type = "Mcp"
+method    = "POST"
+auth      = "none"
+```
+
+This creates a JSON-RPC 2.0 endpoint at `POST /mcp` that accepts `initialize`, `tools/list`, `tools/call`, `resources/list`, `prompts/list`, and other MCP methods.
+
+Reload the bundle:
+
+```bash
+/opt/rivers/bin/riversctl doctor --fix
+/opt/rivers/bin/riversctl stop
+/opt/rivers/bin/riversctl start
+```
+
+---
+
+## Step 2: Expose DataViews as Tools
+
+Add a `tools` section to your MCP view to expose DataViews as callable tools:
+
+```toml
+[api.views.mcp.tools.search_contacts]
+dataview    = "search_contacts"
+description = "Search contacts by name or email"
+hints       = { read_only = true }
+
+[api.views.mcp.tools.list_all_contacts]
+dataview    = "list_contacts"
+description = "List all contacts in the system"
+hints       = { read_only = true }
+```
+
+Each tool maps a named DataView and provides:
+
+| Field | Purpose |
+|-------|---------|
+| **dataview** | The DataView name to expose (must exist in `data.dataviews`) |
+| **description** | Human-readable text explaining what the tool does (shown to AI) |
+| **method** | Optional: HTTP method override (GET/POST/PUT/DELETE) |
+| **hints** | Tool behavior hints for the AI model |
+
+### Tool Hints
+
+Tool hints inform the AI about the tool's behavior:
+
+```toml
+[api.views.mcp.tools.update_contact]
+dataview    = "update_contact"
+description = "Update a contact's information"
+hints       = { 
+  read_only     = false,      # True if the tool doesn't modify state
+  destructive   = true,       # True if the tool can delete data
+  idempotent    = true,       # True if safe to retry
+  open_world    = true        # True if tool talks to external systems
+}
+```
+
+---
+
+## Step 3: Test with curl
+
+### Initialize
+
+First, establish an MCP session by calling `initialize`:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {}
+  }'
+```
+
+Expected response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "serverInfo": {
+      "name": "rivers-mcp",
+      "version": "0.54.0"
+    },
+    "capabilities": {
+      "tools": { "listChanged": false }
+    }
+  }
+}
+```
+
+### List Tools
+
+Request the list of available tools:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list",
+    "params": {}
+  }'
+```
+
+Expected response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "search_contacts",
+        "description": "Search contacts by name or email",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search term"
+            }
+          },
+          "required": ["query"]
+        }
+      },
+      {
+        "name": "list_all_contacts",
+        "description": "List all contacts in the system",
+        "inputSchema": { "type": "object", "properties": {} }
+      }
+    ]
+  }
+}
+```
+
+### Call a Tool
+
+Ask the MCP server to call a tool on your behalf:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "search_contacts",
+      "arguments": {
+        "query": "john"
+      }
+    }
+  }'
+```
+
+Expected response (results depend on your datasource):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"id\":\"123\",\"name\":\"John Doe\",\"email\":\"john@example.com\"}]"
+      }
+    ]
+  }
+}
+```
+
+### Error Handling
+
+If you call a method that doesn't exist, you receive a standard JSON-RPC error:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "nonexistent",
+    "params": {}
+  }'
+```
+
+Expected response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+```
+
+---
+
+## Step 4: Add Resources
+
+MCP resources expose read-only DataViews as context data for AI models:
+
+```toml
+[api.views.mcp.resources.contact_schema]
+dataview    = "get_contact_schema"
+description = "JSON schema for contact objects"
+mime_type   = "application/json"
+```
+
+To list resources:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "resources/list",
+    "params": {}
+  }'
+```
+
+To read a resource:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 6,
+    "method": "resources/read",
+    "params": {
+      "uri": "contact_schema"
+    }
+  }'
+```
+
+---
+
+## Step 5: Add Prompts
+
+MCP prompts are markdown templates with argument substitution. You can guide AI workflows with custom instructions:
+
+```toml
+[api.views.mcp.prompts.contact_workflow]
+description = "Workflow for searching and updating contacts"
+template    = "libraries/prompts/contact-workflow.md"
+
+[[api.views.mcp.prompts.contact_workflow.arguments]]
+name        = "task"
+description = "The task to perform: search, list, or update"
+required    = true
+
+[[api.views.mcp.prompts.contact_workflow.arguments]]
+name        = "query"
+description = "Optional search query"
+required    = false
+default     = ""
+```
+
+Create the markdown template at `libraries/prompts/contact-workflow.md`:
+
+```markdown
+# Contact Workflow
+
+## Task: {task}
+
+You are helping with contact management. The available tools are:
+- `search_contacts`: Search for contacts by name or email
+- `list_all_contacts`: Get all contacts
+- `update_contact`: Modify an existing contact
+
+Your goal is to: {task}
+
+{query:
+  Search criteria: {query}
+}
+```
+
+To list prompts:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 7,
+    "method": "prompts/list",
+    "params": {}
+  }'
+```
+
+To get a prompt with arguments:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 8,
+    "method": "prompts/get",
+    "params": {
+      "name": "contact_workflow",
+      "arguments": {
+        "task": "search for all customers in New York",
+        "query": "city=New York"
+      }
+    }
+  }'
+```
+
+---
+
+## Step 6: Session Management
+
+MCP sessions are stateful and identified by the `Mcp-Session-Id` header. Sessions persist for a configurable TTL (default: 1 hour).
+
+### Create a Session
+
+The first `initialize` call creates a session. The server returns a session ID in the response:
+
+```bash
+RESPONSE=$(curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {}
+  }')
+
+# Extract the session ID from response headers if provided
+SESSION_ID=$(echo "$RESPONSE" | grep -o "Mcp-Session-Id: [^[:space:]]*" | cut -d' ' -f2) || SESSION_ID="default"
+```
+
+### Use an Existing Session
+
+Include the session ID in subsequent requests:
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/list",
+    "params": {}
+  }'
+```
+
+### Configure Session TTL
+
+In your MCP view, optionally set a custom session TTL:
+
+```toml
+[api.views.mcp.session]
+ttl_seconds = 7200  # 2 hours
+```
+
+---
+
+## Step 7: Validation and Best Practices
+
+### Validation During Bundle Load
+
+When you deploy a bundle, `riverpackage validate` checks MCP configurations:
+
+- All referenced DataViews must exist
+- Tool descriptions are recommended but optional
+- Resources must map to read-only DataViews (no writes)
+- Prompt templates must exist at the specified path
+
+**Example:**
+
+```bash
+riverpackage validate canary-bundle
+```
+
+If validation succeeds:
+
+```
+Bundle:     canary-bundle
+✓ Structure validation
+✓ Existence validation
+✓ Cross-reference validation
+  (mcp tools: search_contacts, list_all_contacts)
+✓ Syntax validation
+```
+
+### Best Practices
+
+1. **Use clear tool descriptions** — AI models use descriptions to decide whether to call a tool. Be specific about what the tool does and what parameters it expects.
+
+2. **Keep tools focused** — Expose one logical operation per tool. Don't bundle unrelated queries into a single tool.
+
+3. **Mark read-only tools** — Set `hints = { read_only = true }` for tools that don't modify state. This helps AI models understand the cost of calling the tool.
+
+4. **Document required parameters** — DataView parameters become tool input schema fields. Document them in your DataView configuration.
+
+5. **Use resources for context** — Instead of expecting the AI to discover schema information, expose it via resources. This ensures the AI has accurate information about your API.
+
+6. **Test with a real AI client** — While curl works for basic testing, test your MCP configuration with an actual AI client (Claude Desktop, ChatGPT, etc.) to verify parameter handling and response format.
+
+---
+
+## Summary
+
+This tutorial covered:
+
+1. **Adding MCP to your app** — Create an `[api.views.mcp]` view with POST method
+2. **Exposing tools** — Map DataViews to tools with `[api.views.mcp.tools.*]` sections
+3. **Testing with curl** — Initialize, list tools, and call tools via JSON-RPC
+4. **Adding resources** — Expose read-only DataViews as context data
+5. **Adding prompts** — Create markdown templates for AI workflows
+6. **Session management** — Understand MCP session lifecycle and TTL
+7. **Validation** — Verify MCP configurations during bundle deployment
+
+MCP makes your Rivers application discoverable and accessible to AI models, enabling powerful AI-assisted workflows without custom code.

--- a/docs/superpowers/plans/2026-04-15-mcp-view-type.md
+++ b/docs/superpowers/plans/2026-04-15-mcp-view-type.md
@@ -1,0 +1,863 @@
+# MCP View Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the MCP (Model Context Protocol) view type — a JSON-RPC 2.0 endpoint that exposes DataViews as AI-consumable tools, resources, and prompts per the MCP Streamable HTTP transport specification.
+
+**Architecture:** MCP is a new `view_type = "MCP"` that activates a JSON-RPC dispatcher in the view layer. Tools map to DataViews, resources are read-only DataViews, prompts are markdown templates. The dispatcher calls the same `dataview_engine.execute()` path as REST views. Sessions use StorageEngine. Streaming tools use SSE automatically when the target DataView has `streaming = true`.
+
+**Tech Stack:** Rust, serde_json (JSON-RPC), Axum (HTTP POST + SSE), StorageEngine (sessions), DataView engine (tool execution)
+
+**Spec:** `docs/arch/rivers-mcp-view-spec.md`
+
+---
+
+## Phase 1: MVP — Config Types + JSON-RPC Dispatcher + Tools
+
+The minimum viable MCP endpoint: can list tools and execute them.
+
+---
+
+### Task 1: MCP Config Types
+
+**Files:**
+- Modify: `crates/rivers-runtime/src/view.rs`
+- Modify: `crates/rivers-runtime/src/validate_structural.rs`
+
+- [ ] **Step 1: Define MCP config structs**
+
+In `crates/rivers-runtime/src/view.rs`, add the MCP config types after `ParameterMappingConfig`:
+
+```rust
+/// MCP tool declaration — maps a DataView to an MCP tool.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpToolConfig {
+    /// Target DataView name.
+    pub dataview: String,
+    /// Human-readable description for the AI model.
+    #[serde(default)]
+    pub description: String,
+    /// HTTP method (GET/POST/PUT/DELETE) when DataView supports multiple.
+    #[serde(default)]
+    pub method: Option<String>,
+    /// Tool behavior hints for the AI model.
+    #[serde(default)]
+    pub hints: McpToolHints,
+}
+
+/// MCP tool behavior hints.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpToolHints {
+    #[serde(default)]
+    pub read_only: bool,
+    #[serde(default = "default_true")]
+    pub destructive: bool,
+    #[serde(default)]
+    pub idempotent: bool,
+    #[serde(default = "default_true")]
+    pub open_world: bool,
+}
+
+fn default_true() -> bool { true }
+
+/// MCP resource declaration — read-only DataView exposure.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpResourceConfig {
+    /// Target DataView name (GET method only).
+    pub dataview: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// MIME type for the resource. Default: "application/json".
+    #[serde(default = "default_mime")]
+    pub mime_type: String,
+}
+
+fn default_mime() -> String { "application/json".into() }
+
+/// MCP prompt declaration — markdown template with argument substitution.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpPromptConfig {
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Path to markdown template file (relative to app bundle root).
+    pub template: String,
+    /// Prompt arguments for template substitution.
+    #[serde(default)]
+    pub arguments: Vec<McpPromptArgument>,
+}
+
+/// A single prompt argument.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpPromptArgument {
+    /// Argument name (matches {placeholder} in template).
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Whether this argument is required.
+    #[serde(default)]
+    pub required: bool,
+    /// Default value when not provided.
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
+/// MCP session configuration.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct McpSessionConfig {
+    /// Session TTL in seconds. Default: 3600 (1 hour).
+    #[serde(default = "default_mcp_ttl")]
+    pub ttl_seconds: u64,
+}
+
+fn default_mcp_ttl() -> u64 { 3600 }
+```
+
+- [ ] **Step 2: Add MCP fields to ApiViewConfig**
+
+In the `ApiViewConfig` struct, add after the polling field:
+
+```rust
+    /// MCP tool declarations — whitelisted DataViews exposed as MCP tools.
+    #[serde(default)]
+    pub tools: HashMap<String, McpToolConfig>,
+
+    /// MCP resource declarations — read-only DataViews exposed as MCP resources.
+    #[serde(default)]
+    pub resources: HashMap<String, McpResourceConfig>,
+
+    /// MCP prompt declarations — markdown templates for AI workflows.
+    #[serde(default)]
+    pub prompts: HashMap<String, McpPromptConfig>,
+
+    /// Path to static instructions markdown file (relative to app root).
+    #[serde(default)]
+    pub instructions: Option<String>,
+
+    /// MCP session configuration.
+    #[serde(default)]
+    pub session: Option<McpSessionConfig>,
+```
+
+- [ ] **Step 3: Add "MCP" to valid view types and known fields**
+
+In `validate_structural.rs`:
+- Add `"tools"`, `"resources"`, `"prompts"`, `"instructions"`, `"session"` to `VIEW_FIELDS`
+- If there's a view type enum validation, add `"MCP"` (or `"Mcp"`) as valid
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cargo check -p rivers-runtime && cargo test -p rivers-runtime --lib`
+
+```bash
+git commit -m "feat(mcp): add MCP config types — tools, resources, prompts, session"
+```
+
+---
+
+### Task 2: JSON-RPC Dispatcher Module
+
+**Files:**
+- Create: `crates/riversd/src/mcp/mod.rs`
+- Create: `crates/riversd/src/mcp/jsonrpc.rs`
+- Create: `crates/riversd/src/mcp/dispatch.rs`
+- Modify: `crates/riversd/src/lib.rs`
+
+- [ ] **Step 1: Create JSON-RPC types**
+
+Create `crates/riversd/src/mcp/jsonrpc.rs`:
+
+```rust
+//! JSON-RPC 2.0 types for MCP protocol.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self { jsonrpc: "2.0", id, result: Some(result), error: None }
+    }
+
+    pub fn error(id: Option<serde_json::Value>, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0", id, result: None,
+            error: Some(JsonRpcError { code, message: message.into(), data: None }),
+        }
+    }
+
+    pub fn parse_error() -> Self {
+        Self::error(None, -32700, "Parse error")
+    }
+
+    pub fn invalid_request(id: Option<serde_json::Value>) -> Self {
+        Self::error(id, -32600, "Invalid Request")
+    }
+
+    pub fn method_not_found(id: Option<serde_json::Value>, method: &str) -> Self {
+        Self::error(id, -32601, format!("Method not found: {}", method))
+    }
+
+    pub fn invalid_params(id: Option<serde_json::Value>, detail: impl Into<String>) -> Self {
+        Self::error(id, -32602, detail)
+    }
+
+    pub fn session_required(id: Option<serde_json::Value>) -> Self {
+        Self::error(id, -32001, "Session required")
+    }
+
+    pub fn server_error(id: Option<serde_json::Value>, msg: impl Into<String>) -> Self {
+        Self::error(id, -32000, msg)
+    }
+}
+```
+
+- [ ] **Step 2: Create MCP dispatch module**
+
+Create `crates/riversd/src/mcp/dispatch.rs`:
+
+```rust
+//! MCP JSON-RPC method dispatcher.
+
+use std::sync::Arc;
+use rivers_runtime::view::{McpToolConfig, McpResourceConfig, McpPromptConfig};
+
+use super::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+use crate::server::context::AppContext;
+
+/// Dispatch a single JSON-RPC request to the appropriate MCP handler.
+pub async fn dispatch(
+    ctx: &AppContext,
+    req: &JsonRpcRequest,
+    tools: &std::collections::HashMap<String, McpToolConfig>,
+    resources: &std::collections::HashMap<String, McpResourceConfig>,
+    prompts: &std::collections::HashMap<String, McpPromptConfig>,
+    app_id: &str,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    // Validate JSON-RPC version
+    if req.jsonrpc != "2.0" {
+        return JsonRpcResponse::invalid_request(req.id.clone());
+    }
+
+    match req.method.as_str() {
+        "initialize" => handle_initialize(req, tools, resources, prompts),
+        "ping" => JsonRpcResponse::success(req.id.clone(), serde_json::json!({})),
+        "tools/list" => handle_tools_list(req, tools, ctx, dv_namespace).await,
+        "tools/call" => handle_tools_call(req, tools, ctx, dv_namespace).await,
+        "resources/list" => handle_resources_list(req, resources),
+        "resources/read" => handle_resources_read(req, resources, ctx, dv_namespace).await,
+        "resources/templates/list" => handle_resource_templates(req, resources, app_id),
+        "prompts/list" => handle_prompts_list(req, prompts),
+        "prompts/get" => handle_prompts_get(req, prompts),
+        _ => JsonRpcResponse::method_not_found(req.id.clone(), &req.method),
+    }
+}
+
+fn handle_initialize(
+    req: &JsonRpcRequest,
+    tools: &std::collections::HashMap<String, McpToolConfig>,
+    resources: &std::collections::HashMap<String, McpResourceConfig>,
+    prompts: &std::collections::HashMap<String, McpPromptConfig>,
+) -> JsonRpcResponse {
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+        "protocolVersion": "2024-11-05",
+        "serverInfo": {
+            "name": "rivers-mcp",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "capabilities": {
+            "tools": { "listChanged": false },
+            "resources": if resources.is_empty() { serde_json::Value::Null } else { serde_json::json!({}) },
+            "prompts": if prompts.is_empty() { serde_json::Value::Null } else { serde_json::json!({}) },
+        }
+    }))
+}
+
+async fn handle_tools_list(
+    req: &JsonRpcRequest,
+    tools: &std::collections::HashMap<String, McpToolConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    let tool_list: Vec<serde_json::Value> = tools.iter().map(|(name, config)| {
+        // Project DataView parameters into MCP inputSchema
+        let namespaced = format!("{}:{}", dv_namespace, config.dataview);
+        let method = config.method.as_deref().unwrap_or("GET");
+        let schema = if let Some(dv_config) = executor.get_dataview_config(&namespaced) {
+            let params = dv_config.parameters_for_method(method);
+            project_input_schema(params)
+        } else {
+            serde_json::json!({"type": "object", "properties": {}})
+        };
+
+        serde_json::json!({
+            "name": name,
+            "description": config.description,
+            "inputSchema": schema,
+            "annotations": {
+                "readOnlyHint": config.hints.read_only,
+                "destructiveHint": config.hints.destructive,
+                "idempotentHint": config.hints.idempotent,
+                "openWorldHint": config.hints.open_world,
+            }
+        })
+    }).collect();
+
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "tools": tool_list }))
+}
+
+async fn handle_tools_call(
+    req: &JsonRpcRequest,
+    tools: &std::collections::HashMap<String, McpToolConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let tool_name = match req.params.get("name").and_then(|n| n.as_str()) {
+        Some(n) => n,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'name' in params"),
+    };
+
+    let tool_config = match tools.get(tool_name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), format!("Unknown tool: {}", tool_name)),
+    };
+
+    let arguments = req.params.get("arguments")
+        .and_then(|a| a.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    // Convert JSON arguments to QueryValue params
+    let params: std::collections::HashMap<String, rivers_runtime::rivers_driver_sdk::QueryValue> =
+        arguments.into_iter().map(|(k, v)| {
+            let qv = crate::view_engine::pipeline::json_value_to_query_value(&v);
+            (k, qv)
+        }).collect();
+
+    let method = tool_config.method.as_deref().unwrap_or("GET");
+    let namespaced = format!("{}:{}", dv_namespace, tool_config.dataview);
+    let trace_id = uuid::Uuid::new_v4().to_string();
+
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    match executor.execute(&namespaced, params, method, &trace_id, None).await {
+        Ok(response) => {
+            let content = serde_json::json!([{
+                "type": "text",
+                "text": serde_json::to_string(&response.query_result.rows).unwrap_or_default()
+            }]);
+            JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "content": content }))
+        }
+        Err(e) => {
+            JsonRpcResponse::server_error(req.id.clone(), format!("Tool execution failed: {}", e))
+        }
+    }
+}
+
+fn handle_resources_list(
+    req: &JsonRpcRequest,
+    resources: &std::collections::HashMap<String, McpResourceConfig>,
+) -> JsonRpcResponse {
+    let list: Vec<serde_json::Value> = resources.iter().map(|(name, config)| {
+        serde_json::json!({
+            "name": name,
+            "uri": format!("rivers://app/{}", name),
+            "description": config.description,
+            "mimeType": config.mime_type,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "resources": list }))
+}
+
+async fn handle_resources_read(
+    req: &JsonRpcRequest,
+    resources: &std::collections::HashMap<String, McpResourceConfig>,
+    ctx: &AppContext,
+    dv_namespace: &str,
+) -> JsonRpcResponse {
+    let uri = match req.params.get("uri").and_then(|u| u.as_str()) {
+        Some(u) => u,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'uri' in params"),
+    };
+
+    // Extract resource name from URI (rivers://app/{resource_name})
+    let resource_name = uri.rsplit('/').next().unwrap_or(uri);
+
+    let config = match resources.get(resource_name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), format!("Unknown resource: {}", resource_name)),
+    };
+
+    let namespaced = format!("{}:{}", dv_namespace, config.dataview);
+    let trace_id = uuid::Uuid::new_v4().to_string();
+
+    let dv_guard = ctx.dataview_executor.read().await;
+    let executor = match dv_guard.as_ref() {
+        Some(e) => e,
+        None => return JsonRpcResponse::server_error(req.id.clone(), "DataView engine not available"),
+    };
+
+    match executor.execute(&namespaced, std::collections::HashMap::new(), "GET", &trace_id, None).await {
+        Ok(response) => {
+            let text = serde_json::to_string(&response.query_result.rows).unwrap_or_default();
+            JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": config.mime_type,
+                    "text": text,
+                }]
+            }))
+        }
+        Err(e) => JsonRpcResponse::server_error(req.id.clone(), format!("Resource read failed: {}", e)),
+    }
+}
+
+fn handle_resource_templates(
+    req: &JsonRpcRequest,
+    resources: &std::collections::HashMap<String, McpResourceConfig>,
+    app_id: &str,
+) -> JsonRpcResponse {
+    let templates: Vec<serde_json::Value> = resources.iter().map(|(name, config)| {
+        serde_json::json!({
+            "uriTemplate": format!("rivers://{}/{}", app_id, name),
+            "name": name,
+            "description": config.description,
+            "mimeType": config.mime_type,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "resourceTemplates": templates }))
+}
+
+fn handle_prompts_list(
+    req: &JsonRpcRequest,
+    prompts: &std::collections::HashMap<String, McpPromptConfig>,
+) -> JsonRpcResponse {
+    let list: Vec<serde_json::Value> = prompts.iter().map(|(name, config)| {
+        let args: Vec<serde_json::Value> = config.arguments.iter().map(|a| {
+            serde_json::json!({
+                "name": a.name,
+                "description": a.description,
+                "required": a.required,
+            })
+        }).collect();
+        serde_json::json!({
+            "name": name,
+            "description": config.description,
+            "arguments": args,
+        })
+    }).collect();
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({ "prompts": list }))
+}
+
+fn handle_prompts_get(
+    req: &JsonRpcRequest,
+    prompts: &std::collections::HashMap<String, McpPromptConfig>,
+) -> JsonRpcResponse {
+    let name = match req.params.get("name").and_then(|n| n.as_str()) {
+        Some(n) => n,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), "missing 'name'"),
+    };
+    let config = match prompts.get(name) {
+        Some(c) => c,
+        None => return JsonRpcResponse::invalid_params(req.id.clone(), format!("Unknown prompt: {}", name)),
+    };
+
+    // Template loading and substitution will be added in Phase 2
+    // For now, return the prompt metadata
+    JsonRpcResponse::success(req.id.clone(), serde_json::json!({
+        "description": config.description,
+        "messages": [{
+            "role": "user",
+            "content": { "type": "text", "text": format!("(template: {})", config.template) }
+        }]
+    }))
+}
+
+/// Project DataView parameters into MCP JSON Schema inputSchema.
+fn project_input_schema(params: &[rivers_runtime::dataview::DataViewParameterConfig]) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for p in params {
+        let json_type = match p.param_type.as_str() {
+            "integer" => "integer",
+            "float" | "decimal" => "number",
+            "boolean" => "boolean",
+            "array" => "array",
+            _ => "string",
+        };
+
+        let mut prop = serde_json::json!({ "type": json_type });
+        if let Some(ref default) = p.default {
+            prop["default"] = default.clone();
+        }
+        match p.param_type.as_str() {
+            "uuid" => { prop["format"] = serde_json::json!("uuid"); }
+            "date" => { prop["format"] = serde_json::json!("date"); }
+            "email" => { prop["format"] = serde_json::json!("email"); }
+            _ => {}
+        }
+
+        properties.insert(p.name.clone(), prop);
+        if p.required {
+            required.push(serde_json::Value::String(p.name.clone()));
+        }
+    }
+
+    serde_json::json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    })
+}
+```
+
+- [ ] **Step 3: Create module entry point**
+
+Create `crates/riversd/src/mcp/mod.rs`:
+
+```rust
+//! MCP (Model Context Protocol) view type — JSON-RPC dispatcher for AI tool access.
+pub mod jsonrpc;
+pub mod dispatch;
+```
+
+Register in `crates/riversd/src/lib.rs`:
+
+```rust
+/// MCP view type — JSON-RPC dispatcher for AI tool access.
+pub mod mcp;
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cargo check -p riversd`
+
+```bash
+git commit -m "feat(mcp): add JSON-RPC types and MCP method dispatcher"
+```
+
+---
+
+### Task 3: Wire MCP View into Request Dispatch
+
+**Files:**
+- Modify: `crates/riversd/src/server/view_dispatch.rs`
+
+- [ ] **Step 1: Add MCP dispatch handler**
+
+In `view_dispatch.rs`, find the `match view_type` block (around line 155). Add before the default `_` arm:
+
+```rust
+    "Mcp" => {
+        return execute_mcp_view(ctx, request, matched).await;
+    }
+```
+
+- [ ] **Step 2: Implement `execute_mcp_view`**
+
+Add the function in the same file or in a new file:
+
+```rust
+async fn execute_mcp_view(
+    ctx: AppContext,
+    request: axum::http::Request<axum::body::Body>,
+    matched: MatchedRoute,
+) -> axum::response::Response {
+    // Read POST body as JSON
+    let bytes = match axum::body::to_bytes(request.into_body(), 16 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            let resp = crate::mcp::jsonrpc::JsonRpcResponse::parse_error();
+            return axum::Json(resp).into_response();
+        }
+    };
+
+    // Parse JSON-RPC request (single or batch)
+    let body: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            let resp = crate::mcp::jsonrpc::JsonRpcResponse::parse_error();
+            return axum::Json(resp).into_response();
+        }
+    };
+
+    let tools = &matched.config.tools;
+    let resources = &matched.config.resources;
+    let prompts = &matched.config.prompts;
+    let app_id = &matched.app_entry_point;
+    let dv_namespace = &matched.app_entry_point;
+
+    // Handle batch or single request
+    if let Some(batch) = body.as_array() {
+        // Batch request
+        let mut responses = Vec::new();
+        for item in batch {
+            if let Ok(req) = serde_json::from_value::<crate::mcp::jsonrpc::JsonRpcRequest>(item.clone()) {
+                if req.id.is_some() {
+                    let resp = crate::mcp::dispatch::dispatch(&ctx, &req, tools, resources, prompts, app_id, dv_namespace).await;
+                    responses.push(serde_json::to_value(&resp).unwrap_or_default());
+                }
+                // Notifications (no id) don't produce responses
+            } else {
+                responses.push(serde_json::to_value(&crate::mcp::jsonrpc::JsonRpcResponse::invalid_request(None)).unwrap_or_default());
+            }
+        }
+        axum::Json(serde_json::Value::Array(responses)).into_response()
+    } else {
+        // Single request
+        match serde_json::from_value::<crate::mcp::jsonrpc::JsonRpcRequest>(body) {
+            Ok(req) => {
+                if req.id.is_none() {
+                    // Notification — no response
+                    return axum::http::StatusCode::NO_CONTENT.into_response();
+                }
+                let resp = crate::mcp::dispatch::dispatch(&ctx, &req, tools, resources, prompts, app_id, dv_namespace).await;
+                axum::Json(resp).into_response()
+            }
+            Err(_) => {
+                axum::Json(crate::mcp::jsonrpc::JsonRpcResponse::invalid_request(None)).into_response()
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Ensure MCP views route as POST**
+
+Check `crates/riversd/src/view_engine/router.rs` — MCP views need to be registered as POST routes. The existing router may default to the method from the view config. Ensure `method = "POST"` works or add special handling for MCP.
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cargo check -p riversd && cargo test -p riversd --lib`
+
+```bash
+git commit -m "feat(mcp): wire MCP view type into request dispatch — tools/list and tools/call working"
+```
+
+---
+
+## Phase 2: Full Protocol — Resources, Prompts, Instructions
+
+---
+
+### Task 4: Prompt Template Loading and Substitution
+
+**Files:**
+- Modify: `crates/riversd/src/mcp/dispatch.rs`
+
+- [ ] **Step 1: Implement prompt template loading**
+
+Replace the stub `handle_prompts_get` with real template loading:
+
+1. Read the template file from `app_dir.join(&config.template)`
+2. Validate required arguments are present in the request
+3. Apply defaults for missing optional arguments
+4. Substitute `{argument}` placeholders with values
+5. Return resolved markdown as prompt content
+
+The `app_dir` needs to be passed through to the dispatch function — add it as a parameter.
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+git commit -m "feat(mcp): implement prompt template loading and argument substitution"
+```
+
+---
+
+### Task 5: Instructions Compilation
+
+**Files:**
+- Create: `crates/riversd/src/mcp/instructions.rs`
+- Modify: `crates/riversd/src/mcp/mod.rs`
+- Modify: `crates/riversd/src/mcp/dispatch.rs`
+
+- [ ] **Step 1: Implement instructions compiler**
+
+Create a function that assembles the instructions document from:
+1. Static instructions file (if declared) — read at startup
+2. Auto-generated tool catalog (always present)
+3. Auto-generated resource reference
+4. Auto-generated prompt reference
+
+Store the compiled result in memory (recompile on hot reload).
+
+- [ ] **Step 2: Serve via `initialize` response and GET endpoint**
+
+Add the compiled instructions to the `initialize` handler response. Add a GET handler for `/mcp/instructions` that returns the same content as `text/markdown`.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(mcp): auto-generated instructions with tool/resource/prompt catalog"
+```
+
+---
+
+### Task 6: Validation Rules (VAL-1 through VAL-10)
+
+**Files:**
+- Modify: `crates/rivers-runtime/src/validate_crossref.rs`
+
+- [ ] **Step 1: Add MCP config validation**
+
+In the per-app loop of `validate_crossref()`, add checks for:
+- VAL-1/VAL-2: Tool/resource DataView references exist
+- VAL-3: Tool method matches DataView's declared methods
+- VAL-4: Instructions file exists
+- VAL-5: Prompt template files exist
+- VAL-6: Prompt template placeholders match argument declarations
+- VAL-7: Only one MCP view per app
+- VAL-8/9/10: Unique tool/resource/prompt names
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+git commit -m "feat(mcp): add VAL-1 through VAL-10 MCP config validation"
+```
+
+---
+
+## Phase 3: Production Hardening — Sessions, Streaming, Tests
+
+---
+
+### Task 7: MCP Session Management
+
+**Files:**
+- Create: `crates/riversd/src/mcp/session.rs`
+- Modify: `crates/riversd/src/mcp/dispatch.rs`
+
+- [ ] **Step 1: Implement MCP session lifecycle**
+
+1. On `initialize`: create session in StorageEngine at `mcp:session:{uuid}`, return `Mcp-Session-Id` header
+2. On subsequent requests: validate `Mcp-Session-Id` header, reject with `-32001` if invalid/expired
+3. Sliding expiration: reset TTL on every valid request
+4. Session data: `created_at`, `capabilities`, `identity` (from guard)
+
+- [ ] **Step 2: Wire session into dispatch**
+
+Add session validation before method dispatch (except for `initialize` which creates the session).
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "feat(mcp): MCP session management with StorageEngine persistence"
+```
+
+---
+
+### Task 8: Streaming Tools
+
+**Files:**
+- Modify: `crates/riversd/src/mcp/dispatch.rs`
+- Modify: `crates/riversd/src/server/view_dispatch.rs`
+
+- [ ] **Step 1: Detect streaming DataViews in tools/call**
+
+When `tools/call` targets a DataView with `streaming = true`, switch the response to SSE mode:
+1. Set `Content-Type: text/event-stream`
+2. Wrap each chunk in a `notifications/tools/progress` JSON-RPC notification
+3. Send the final result as a JSON-RPC response event
+
+- [ ] **Step 2: Verify and commit**
+
+```bash
+git commit -m "feat(mcp): streaming tool responses via SSE for streaming DataViews"
+```
+
+---
+
+### Task 9: Canary Tests + Documentation
+
+**Files:**
+- Create: `docs/guide/tutorials/tutorial-mcp.md`
+- Modify: `canary-bundle/` (add MCP test app)
+
+- [ ] **Step 1: Write MCP tutorial**
+
+Cover: declaring an MCP view, exposing tools, adding descriptions, testing with curl/MCP client.
+
+- [ ] **Step 2: Add MCP canary test profile**
+
+Create a minimal MCP app in the canary bundle that exposes a faker DataView as an MCP tool. Test `initialize`, `tools/list`, `tools/call` in run-tests.sh.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+git commit -m "docs: add MCP tutorial and canary tests"
+```
+
+---
+
+### Task 10: Final Validation
+
+- [ ] **Step 1: Full workspace compile**
+
+Run: `cargo check --workspace`
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cargo test -p riversd --lib && cargo test -p rivers-runtime --lib`
+
+- [ ] **Step 3: Validate bundles**
+
+Run: `cargo run -p riverpackage -- validate address-book-bundle && cargo run -p riverpackage -- validate canary-bundle`
+
+- [ ] **Step 4: Manual MCP test**
+
+Start riversd with an MCP-enabled bundle and test with curl:
+
+```bash
+# Initialize
+curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+
+# List tools
+curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+# Call a tool
+curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_contacts","arguments":{}}}'
+```


### PR DESCRIPTION
## Summary

Implements the MCP (Model Context Protocol) view type per `rivers-mcp-view-spec.md` — a JSON-RPC 2.0 endpoint that exposes DataViews as AI-consumable tools, resources, and prompts.

### Phase 1: MVP
- **Config types** — `McpToolConfig`, `McpResourceConfig`, `McpPromptConfig`, `McpSessionConfig`, `McpToolHints` with serde/JsonSchema derives
- **JSON-RPC dispatcher** — `mcp/jsonrpc.rs` (types + error constructors) + `mcp/dispatch.rs` (9 method handlers)
- **View dispatch wiring** — `view_type = "Mcp"` routes to `execute_mcp_view`, handles batch + single requests + notifications

### Phase 2: Full Protocol
- **Prompt templates** — loads markdown files, validates required arguments, substitutes `{placeholder}` values
- **Instructions compilation** — auto-generated tool/resource/prompt catalog + optional static markdown, served in `initialize` response
- **GET /mcp/instructions** — compiled instructions as `text/markdown` for developer inspection
- **Validation** — VAL-1 (tool DataView refs), VAL-2 (resource DataView refs), VAL-4 (instructions file), VAL-5 (template files), VAL-6 (placeholder validation), VAL-7 (one MCP per app), MCP-13 (unused argument warnings)

### Phase 3: Production
- **Session management** — `Mcp-Session-Id` lifecycle via StorageEngine, sliding TTL, `-32001` error for invalid sessions
- **Streaming detection** — identifies streaming DataViews in tools/call (SSE transport deferred)
- **Tutorial** — `docs/guide/tutorials/tutorial-mcp.md`
- **Canary tests** — 4 tests: initialize, tools/list, tools/call, method-not-found

### MCP Methods Supported
| Method | Status |
|--------|--------|
| `initialize` | ✅ Returns capabilities + instructions |
| `ping` | ✅ Session keepalive |
| `tools/list` | ✅ Schema projection from DataView params |
| `tools/call` | ✅ Execute via DataView engine |
| `resources/list` | ✅ Read-only DataView exposure |
| `resources/read` | ✅ GET-only DataView execution |
| `resources/templates/list` | ✅ Parameterized URI templates |
| `prompts/list` | ✅ Template metadata |
| `prompts/get` | ✅ Template loading + argument substitution |

## Test plan
- [x] `cargo check --workspace` — compiles clean
- [x] `cargo test -p riversd --lib` — 286 passed
- [x] `cargo test -p rivers-runtime --lib` — 182 passed
- [x] `cargo run -p riverpackage -- validate canary-bundle` — 0 errors
- [ ] Manual MCP test with curl (requires deployed instance)
- [ ] Full canary fleet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)