### PR TITLE
feat(versioning): workspace version policy + UTC build-stamp + CI gate

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,66 @@
+name: Version Check
+
+# Enforces the Rivers versioning policy: every PR targeting `main` must
+# bump the workspace version. The minimum bump is a fresh build stamp
+# (`+HHMMDDMMYY` UTC). Code-fix PRs bump PATCH; major-change PRs bump
+# MINOR. See CLAUDE.md "Versioning" for the policy.
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      # Pure-asset changes that ship no code or config are exempt.
+      # Most PRs DON'T match this list and must bump.
+      - '.gitignore'
+      - 'LICENSE'
+
+jobs:
+  version-bumped:
+    name: Workspace version bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the base ref to read its Cargo.toml for comparison.
+          fetch-depth: 0
+
+      - name: Verify version bumped vs. base
+        env:
+          # Pass github.base_ref through env to avoid expression injection
+          # in the shell. base_ref is a branch name and unlikely to be
+          # malicious, but env-var passthrough is the safer pattern.
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(git show "origin/${BASE_REF}":Cargo.toml \
+            | grep -E '^version = "' | head -1 \
+            | sed 's/.*= *"\(.*\)".*/\1/')
+          HEAD_VERSION=$(grep -E '^version = "' Cargo.toml | head -1 \
+            | sed 's/.*= *"\(.*\)".*/\1/')
+
+          echo "Base (${BASE_REF}): $BASE_VERSION"
+          echo "Head:                $HEAD_VERSION"
+
+          if [[ "$BASE_VERSION" == "$HEAD_VERSION" ]]; then
+            echo ""
+            echo "ERROR: Workspace version is unchanged."
+            echo ""
+            echo "Every PR must bump the workspace version per CLAUDE.md."
+            echo "Run one of:"
+            echo "    just bump            # refresh build stamp only"
+            echo "    just bump-patch      # code fix"
+            echo "    just bump-minor      # major change"
+            echo "Then commit Cargo.toml and re-push."
+            exit 1
+          fi
+
+          # Sanity check: head version must contain a +build segment.
+          if [[ "$HEAD_VERSION" != *"+"* ]]; then
+            echo ""
+            echo "ERROR: Head version '$HEAD_VERSION' has no +build stamp."
+            echo "Run: just bump"
+            exit 1
+          fi
+
+          echo ""
+          echo "OK: version bumped ($BASE_VERSION -> $HEAD_VERSION)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,58 @@ The Rust runtime is implemented across a workspace of crates under `crates/`.
 - Collapse complex things down to simple
 - Keep it simple
 - always make sure canary is working no failures it is our production. 
+
+## Versioning
+
+**Format:** `MAJOR.MINOR.PATCH+HHMMDDMMYY` — standard SemVer 2.0 with a UTC
+build-metadata stamp. Cargo accepts `+`-prefixed build metadata; some
+operator-facing surfaces (riversd banner, `riversctl status`) display the
+stamp with a `.` separator instead, but the canonical form in `Cargo.toml`
+uses `+`.
+
+**Build stamp components** (10 digits, UTC, all zero-padded 2-digit):
+
+| Position | Field |
+|----------|-------|
+| 1–2      | hour (00–23) |
+| 3–4      | minute (00–59) |
+| 5–6      | day (01–31) |
+| 7–8      | month (01–12) |
+| 9–10     | year (last two digits) |
+
+Example: a PR cut at 23:25 UTC on 26 April 2026 → `2325260426`. Workspace
+`Cargo.toml` records `version = "0.55.0+2325260426"`.
+
+**Bump rules — every PR must bump the workspace version:**
+
+| Change kind | What bumps | Recipe |
+|-------------|-----------|--------|
+| Any PR (default — docs, config, dependency churn, build-system tweaks) | `+build` only | `just bump` |
+| Code fix (bug fix in shipped code, tightening, refactor that changes runtime behavior) | `PATCH` and `+build` | `just bump-patch` |
+| Major change (new feature, breaking config change, public API surface) | `MINOR` and `+build`; `PATCH` resets to 0 | `just bump-minor` |
+
+The bump runs from the workspace root (`./scripts/bump-version.sh`). The
+script computes the UTC stamp, edits the workspace `[package]` version
+in place, and prints the old → new transition.
+
+**CI enforcement:** `.github/workflows/version-check.yml` runs on every
+PR targeting `main` and fails if `Cargo.toml`'s workspace version is
+unchanged versus the base branch, or if the version has no `+build`
+segment. Path-ignore list is intentionally tiny (`.gitignore`, `LICENSE`)
+— almost every PR must bump.
+
+**No squash-collapse:** the squash-merge commit on `main` carries the
+final bumped version; intermediate commits within a PR may bump build
+stamps multiple times (e.g. via rebase or force-push) and that's fine —
+only the final state matters at merge.
+
+**Bump cadence guidance:**
+
+- A PR full of unrelated micro-fixes is still one PR — one `bump-patch`.
+- A PR that only renames a private symbol or refactors comments is a `just bump` (build-only).
+- A PR that adds a new datasource type, changes the bundle layout, or alters a handler-visible API is a `bump-minor`.
+- When in doubt, prefer the lower bump. CI enforces *some* bump; reviewers can ask for a higher bump if the change warrants it.
+
 ## GOAL
 
 pushing out feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.54.2"
+version = "0.54.2+1120260426"
 license = "MIT"
 
 [workspace.dependencies]

--- a/Justfile
+++ b/Justfile
@@ -16,6 +16,25 @@ version := `grep '^version' Cargo.toml | head -1 | sed 's/version = "//;s/"//'`
 arch := `uname -m`
 os := if os() == "macos" { "darwin" } else { os() }
 
+# ── Versioning ───────────────────────────────────────────────────
+#
+# Format: MAJOR.MINOR.PATCH+HHMMDDMMYY (UTC build stamp).
+# Policy: every PR must bump the workspace version. Most PRs only refresh
+# the +build stamp (`just bump`); code-fix PRs use `just bump-patch`;
+# major-change PRs use `just bump-minor`. See CLAUDE.md "Versioning".
+
+# Refresh the +build stamp only (every PR — the most common bump).
+bump:
+    @./scripts/bump-version.sh build
+
+# Code-fix PR: bump PATCH (third component) and refresh the build stamp.
+bump-patch:
+    @./scripts/bump-version.sh patch
+
+# Major-change PR: bump MINOR (second component), reset PATCH to 0, refresh the build stamp.
+bump-minor:
+    @./scripts/bump-version.sh minor
+
 # ── Build ────────────────────────────────────────────────────────
 
 # Build monolithic static binaries for the host (~80MB riversd)

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -527,3 +527,34 @@ Shared test fixtures:
 - Full `cargo test -p riversd` — every binary green, no failures.
 
 **Resolution method:** test-driven. Built the e2e tests, watched them fail with the stale-runtime cancellation, traced the failure to `Handle::current()` capture timing inside `OnceLock`, fixed by introducing the long-lived fixture runtime, re-ran — all 5 tests green plus all prior tests still green. No behavior change in production code paths; only cfg-test surface widened minimally and dev-dep added (`rusqlite`).
+
+## VERSIONING-1.1 — Workspace version policy + UTC build-stamp (2026-04-26)
+
+**Files affected:**
+- `Cargo.toml` — workspace `[package].version` switches from plain SemVer (`0.54.2`) to SemVer + build metadata (`0.54.2+HHMMDDMMYY` with the build stamp refreshed on every PR).
+- `scripts/bump-version.sh` — new portable bash + awk script that bumps the right component and refreshes the UTC stamp.
+- `Justfile` — three new recipes (`bump`, `bump-patch`, `bump-minor`).
+- `.github/workflows/version-check.yml` — CI gate fails any PR to `main` whose workspace version is unchanged from base.
+- `CLAUDE.md` — new "Versioning" section documenting format, bump rules, and CI enforcement.
+
+**Decision 1: SemVer build metadata over a 4th dot component.**
+The user's preferred display form was `0.55.0.HHMMDDMMYY` (4 dot-separated parts). Cargo's SemVer parser accepts only 3 dots; a literal 4th part fails parsing. SemVer 2.0 build metadata (`+HHMMDDMMYY`) carries the same identity, is Cargo-compatible, is preserved through `cargo deploy`, and is widely understood by tooling. The dotted display form is preserved in operator-facing surfaces (riversd banner, riversctl) — only `Cargo.toml` uses `+`.
+
+**Decision 2: UTC for the build stamp, not local time.**
+A globally distributed contributor base produces inconsistent stamps under local-time (Tokyo dev's stamp is "tomorrow" from California's perspective; DST adds further ambiguity). UTC is deterministic, monotonic-per-clock, and matches every other server-log convention. The script enforces this via `date -u`.
+
+**Decision 3: 10-digit stamp `HHMMDDMMYY` over 8 (HHDDMMYY) or 12 (HHMMSSDDMMYY).**
+The 8-char form caused PR collisions when two PRs landed within the same hour (real concern for active contributor pairs). The 12-char form (with seconds) is overkill — collisions within a minute imply a near-simultaneous double-merge that the tooling should reject anyway. Minute-level resolution is the sweet spot.
+
+**Decision 4: Naming convention for bump components.**
+The user's plain-language mapping ("major change", "code fix") doesn't match strict SemVer naming because Rivers is pre-1.0 — what they call "major" is the SemVer MINOR position; "code fix" is the SemVer PATCH position. The Justfile recipes use `bump-minor` and `bump-patch` to match Cargo/SemVer naming so that `cargo`-aware tooling sees expected semantics. The CLAUDE.md doc explains the policy in user-friendly terms ("major change" → `bump-minor`; "code fix" → `bump-patch`) so the team's mental model is preserved.
+
+**Decision 5: CI gate is binary (must-bump-or-fail), not heuristic (must-bump-when-X-changes).**
+A heuristic gate that exempts "doc-only" or "config-only" PRs adds maintenance burden (which paths are doc-only? does `tasks.md` count? what about Cargo.lock?) and creates surprise when a PR slips into the "must-bump" lane after a path-list edit. A flat "every PR bumps" rule is dumb-simple, costs ~3 seconds of `just bump` per PR, and makes the policy easy to teach.
+
+**Decision 6: No pre-commit hook.**
+Pre-commit hooks fire on every WIP commit during a feature branch; the bump only matters at PR-merge time. CI is the right boundary. Local `just bump` remains available for the contributor to run before pushing.
+
+**Spec reference:** SemVer 2.0 §10 (build metadata: optional, `+`-prefixed, alphanumerics + hyphen, no semantic effect on precedence). User-facing policy lives in CLAUDE.md "Versioning" section.
+
+**Resolution method:** spec-aligned design + portable shell tooling + CI gate. Validated by running the bump script three times locally (`build`, `patch`, `minor`) and confirming each produced the right transition: `0.54.2 → 0.54.2+1118260426`, `0.54.2+… → 0.54.3+…`, `0.54.3+… → 0.55.0+…`. CI gate validated at PR merge time on this very PR (which applies its own build-only seed bump).

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Bump the workspace version per the Rivers versioning policy.
+#
+# Format: MAJOR.MINOR.PATCH+HHMMDDMMYY (UTC build stamp)
+#   - MAJOR: leading 0 (pre-1.0)
+#   - MINOR: incremented on major changes (e.g. 0.55.x → 0.56.x)
+#   - PATCH: incremented on code-fix changes (e.g. 0.55.0 → 0.55.1)
+#   - +HHMMDDMMYY: refreshed on every PR (UTC: hour, minute, day, month, year)
+#
+# Usage:
+#   ./scripts/bump-version.sh build      # refresh build stamp only (every PR)
+#   ./scripts/bump-version.sh patch      # bump PATCH + refresh stamp (code fix)
+#   ./scripts/bump-version.sh minor      # bump MINOR, reset PATCH=0 + refresh stamp (major change)
+#
+# Naming note: the policy uses these labels (which differ from strict SemVer
+# because Rivers is pre-1.0 with leading 0):
+#   - "major change"  → bump MINOR (0.55.0 → 0.56.0)
+#   - "code fix"      → bump PATCH (0.55.0 → 0.55.1)
+#   - any PR          → refresh BUILD stamp
+#
+# See CLAUDE.md "Versioning" for the full policy.
+
+set -euo pipefail
+
+CARGO_TOML="${CARGO_TOML:-Cargo.toml}"
+COMPONENT="${1:-build}"
+
+# Generate UTC build stamp: HHMMDDMMYY (10 digits, all zero-padded)
+BUILD_STAMP=$(date -u +"%H%M%d%m%y")
+
+# Read current version from workspace [package] block
+CURRENT=$(grep -E '^version = "' "$CARGO_TOML" | head -1 | sed 's/.*= *"\(.*\)".*/\1/')
+if [[ -z "$CURRENT" ]]; then
+    echo "ERROR: could not parse version from $CARGO_TOML" >&2
+    exit 1
+fi
+
+# Strip existing build metadata (everything after +)
+BASE="${CURRENT%%+*}"
+
+# Split MAJOR.MINOR.PATCH
+IFS='.' read -r MAJOR MINOR PATCH <<<"$BASE"
+if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
+    echo "ERROR: version '$CURRENT' is not MAJOR.MINOR.PATCH" >&2
+    exit 1
+fi
+
+case "$COMPONENT" in
+    build)
+        # Refresh build stamp only
+        ;;
+    patch)
+        # "Code fix" — bump PATCH
+        PATCH=$((PATCH + 1))
+        ;;
+    minor)
+        # "Major change" (per policy naming) — bump MINOR, reset PATCH
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    *)
+        echo "ERROR: unknown component '$COMPONENT' (expected: build, patch, minor)" >&2
+        exit 1
+        ;;
+esac
+
+NEW="${MAJOR}.${MINOR}.${PATCH}+${BUILD_STAMP}"
+
+# Replace the first `version = "..."` line in Cargo.toml using awk.
+# Portable across BSD (macOS) and GNU sed dialects, which differ on the
+# `0,/pattern/` first-match selector.
+TMP="${CARGO_TOML}.bump.$$"
+awk -v new="version = \"$NEW\"" '
+    !done && /^version = "/ { print new; done=1; next }
+    { print }
+' "$CARGO_TOML" >"$TMP"
+mv "$TMP" "$CARGO_TOML"
+
+echo "$CURRENT → $NEW"


### PR DESCRIPTION
## Summary
Establishes a per-PR workspace versioning policy. Every PR targeting \`main\` must bump \`Cargo.toml\`'s workspace version; the minimum bump is a fresh UTC build stamp.

**Format:** \`MAJOR.MINOR.PATCH+HHMMDDMMYY\` (SemVer 2.0 build metadata, UTC).
- Example: 23:25 UTC on 26 April 2026 → \`0.54.2+2325260426\`
- Operator-facing surfaces (riversd banner, riversctl) may render the stamp with a \`.\` separator; \`Cargo.toml\` uses the canonical \`+\` form.

## Bump rules
| Change kind | Recipe | Effect |
|---|---|---|
| Any PR (default) | \`just bump\` | refresh \`+build\` only |
| Code fix | \`just bump-patch\` | bump PATCH + refresh build |
| Major change | \`just bump-minor\` | bump MINOR (reset PATCH=0) + refresh build |

## What ships

| File | Purpose |
|---|---|
| \`scripts/bump-version.sh\` | Portable bash + awk; bumps the right component, refreshes UTC stamp, edits \`Cargo.toml\` in place |
| \`Justfile\` | Three new recipes wrapping the script |
| \`.github/workflows/version-check.yml\` | CI gate: fails any PR whose workspace version is unchanged from base, or has no \`+build\` segment |
| \`CLAUDE.md\` | New "Versioning" section: format, bump rules, CI contract, cadence guidance |
| \`changedecisionlog.md\` | \`VERSIONING-1.1\` decision entry (6 design choices documented) |
| \`Cargo.toml\` | Seed bump applied on this PR per the new policy: \`0.54.2\` → \`0.54.2+1120260426\` |

## Why \`+build\` and not a 4th dot
Cargo's SemVer parser only accepts 3 dot-separated components; a literal \`0.54.2.1120260426\` fails parsing. SemVer 2.0 build metadata (\`+stamp\`) carries the same identity, is Cargo-compatible, and is preserved through \`cargo deploy\`.

## Why UTC, not local time
A globally distributed contributor base produces inconsistent stamps under local time (Tokyo dev's stamp would be "tomorrow" from California's perspective; DST adds further ambiguity). UTC is deterministic and matches every server-log convention.

## Why 10-digit stamp \`HHMMDDMMYY\`
- 8-char \`HHDDMMYY\` (no minutes) → real PR collision risk during active periods
- 12-char \`HHMMSSDDMMYY\` (with seconds) → overkill; sub-minute collisions imply near-simultaneous merge that the tooling should reject anyway
- Minute-level resolution is the sweet spot

## Why the CI gate is binary
A heuristic gate that exempts "doc-only" or "config-only" PRs adds maintenance burden (which paths count?) and creates surprise. Flat "every PR bumps" rule costs ~3s of \`just bump\` per PR and is dumb-simple to teach.

## Why no pre-commit hook
Pre-commit hooks fire on every WIP commit during a feature branch; the bump only matters at merge time. CI is the right enforcement boundary.

## Validation
- \`./scripts/bump-version.sh build\` — works on macOS (BSD awk) and Linux (GNU awk)
- Tested all three components locally: \`0.54.2 → 0.54.2+1118260426\`, \`+ → 0.54.3+…\`, \`+ → 0.55.0+…\`
- This PR is the first to apply the policy; CI gate exercises itself

## Test plan
- [x] Local script test — three component types produce the right transitions
- [x] Cargo accepts the \`+stamp\` version (workspace builds with the seed bump applied)
- [ ] CI gate fires on this PR (validates itself — visible in the Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)