### PR TITLE
docs(versioning): tighten the major-change definition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ Example: a PR cut at 23:25 UTC on 26 April 2026 → `2325260426`. Workspace
 | Change kind | What bumps | Recipe |
 |-------------|-----------|--------|
 | Any PR (default — docs, config, dependency churn, build-system tweaks) | `+build` only | `just bump` |
-| Code fix (bug fix in shipped code, tightening, refactor that changes runtime behavior) | `PATCH` and `+build` | `just bump-patch` |
-| Major change (new feature, breaking config change, public API surface) | `MINOR` and `+build`; `PATCH` resets to 0 | `just bump-minor` |
+| Code fix (bug fix in shipped code, closing a documented-but-missing API, tightening, refactor that changes runtime behavior) | `PATCH` and `+build` | `just bump-patch` |
+| Major change — **genuinely new conceptual capability** (new datasource type, new engine, new bundle structure, breaking config) | `MINOR` and `+build`; `PATCH` resets to 0 | `just bump-minor` |
 
 The bump runs from the workspace root (`./scripts/bump-version.sh`). The
 script computes the UTC stamp, edits the workspace `[package]` version
@@ -93,7 +93,8 @@ only the final state matters at merge.
 
 - A PR full of unrelated micro-fixes is still one PR — one `bump-patch`.
 - A PR that only renames a private symbol or refactors comments is a `just bump` (build-only).
-- A PR that adds a new datasource type, changes the bundle layout, or alters a handler-visible API is a `bump-minor`.
+- A PR that closes a **documented-but-missing** method (e.g. spec advertises `Rivers.db.query`, implementation doesn't install it; or a helper method that the docs/tutorial promised but the code never shipped) is a `bump-patch` — it's filling a gap, not adding new ground.
+- A PR that introduces **genuinely new ground** — a datasource type that didn't exist before, a new engine, a new bundle layout, a breaking config change — is a `bump-minor`.
 - When in doubt, prefer the lower bump. CI enforces *some* bump; reviewers can ask for a higher bump if the change warrants it.
 
 ## GOAL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.55.0+1254260426"
+version = "0.55.0+1942260426"
 license = "MIT"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary
Tightens the bump-rule wording in \`CLAUDE.md\` "Versioning" so closing a documented-but-missing API method is a \`bump-patch\`, not \`bump-minor\`. Reserves MINOR for genuinely new capabilities.

## Why
The original wording listed "public API surface" as a major-change trigger. That's too broad — it would flag any PR that adds or restores a method on the \`Rivers\` global as a major change.

Two genuinely different categories were being conflated:

- **Closing a documented-but-missing API** (spec advertises \`Rivers.db.query\`, code never installed it; tutorial promises a helper that doesn't exist) is a *fix*. The user-facing capability was always supposed to exist. → \`bump-patch\`
- **Introducing genuinely new ground** (new datasource type, new engine, new bundle layout, breaking config) is a *capability*. → \`bump-minor\`

After this PR, MINOR numbers reserve their meaning for new conceptual ground; PATCH numbers carry the bulk of the actual work (which is closing gaps).

## Diff
```diff
- | Major change (new feature, breaking config change, public API surface) | …
+ | Major change — **genuinely new conceptual capability** (new datasource type, new engine, new bundle structure, breaking config) | …
```

Plus a clarifying bullet in the cadence-guidance section explicitly calling out documented-but-missing methods as patch bumps.

## Version
\`just bump\` (build-only): \`0.55.0+1254260426\` → \`0.55.0+1942260426\`. Docs-only, no behavior change.

## Test plan
- [x] Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)