### PR TITLE
feat(crypto): Rivers.crypto.sha256 + sha512 (Bug 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5566,7 +5566,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5607,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "serde",
  "serde_json",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "clap",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "rivers-lockbox-engine",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "chrono",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-trait",
  "hex",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-nats",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "age",
  "async-trait",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-trait",
  "hex",
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-trait",
  "redis",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.55.0+1232260426"
+version = "0.55.1+1947260426"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.55.0+1942260426"
+version = "0.55.1+1947260426"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/riversd/src/process_pool/v8_engine/rivers_global.rs
+++ b/crates/riversd/src/process_pool/v8_engine/rivers_global.rs
@@ -560,6 +560,53 @@ pub(super) fn inject_rivers_global(
     let decrypt_key = v8_str(scope, "decrypt")?;
     crypto_obj.set(scope, decrypt_key.into(), decrypt_fn.into());
 
+    // Rivers.crypto.sha256(input: string): string
+    //
+    // Returns the lowercase hex-encoded SHA-256 digest of the UTF-8 bytes of
+    // `input`. Pure helper — no key material involved (use Rivers.crypto.hmac
+    // for keyed authentication).
+    //
+    // Per docs/bugs/case-rivers-crypto-textencoder-gap.md (Bug 1).
+    let sha256_fn = v8::Function::new(
+        scope,
+        |scope: &mut v8::HandleScope,
+         args: v8::FunctionCallbackArguments,
+         mut rv: v8::ReturnValue| {
+            use sha2::{Digest, Sha256};
+            let input = args.get(0).to_rust_string_lossy(scope);
+            let result = hex::encode(Sha256::digest(input.as_bytes()));
+            if let Some(v8_str) = v8::String::new(scope, &result) {
+                rv.set(v8_str.into());
+            }
+        },
+    )
+    .ok_or_else(|| TaskError::Internal("failed to create Rivers.crypto.sha256".into()))?;
+    let sha256_key = v8_str(scope, "sha256")?;
+    crypto_obj.set(scope, sha256_key.into(), sha256_fn.into());
+
+    // Rivers.crypto.sha512(input: string): string
+    //
+    // Returns the lowercase hex-encoded SHA-512 digest of the UTF-8 bytes of
+    // `input`. Pure helper — no key material involved.
+    //
+    // Per docs/bugs/case-rivers-crypto-textencoder-gap.md (Bug 1).
+    let sha512_fn = v8::Function::new(
+        scope,
+        |scope: &mut v8::HandleScope,
+         args: v8::FunctionCallbackArguments,
+         mut rv: v8::ReturnValue| {
+            use sha2::{Digest, Sha512};
+            let input = args.get(0).to_rust_string_lossy(scope);
+            let result = hex::encode(Sha512::digest(input.as_bytes()));
+            if let Some(v8_str) = v8::String::new(scope, &result) {
+                rv.set(v8_str.into());
+            }
+        },
+    )
+    .ok_or_else(|| TaskError::Internal("failed to create Rivers.crypto.sha512".into()))?;
+    let sha512_key = v8_str(scope, "sha512")?;
+    crypto_obj.set(scope, sha512_key.into(), sha512_fn.into());
+
     let crypto_key = v8_str(scope, "crypto")?;
     rivers_obj.set(scope, crypto_key.into(), crypto_obj.into());
 

--- a/crates/riversd/tests/v8_bridge_tests.rs
+++ b/crates/riversd/tests/v8_bridge_tests.rs
@@ -252,6 +252,56 @@ async fn rivers_crypto_hmac_deterministic() {
     assert_eq!(v["same"], true);
 }
 
+/// Bug 1: Rivers.crypto.sha256 — known SHA-256 vector for "abc" (NIST FIPS 180-4).
+#[tokio::test]
+async fn rivers_crypto_sha256_known_vector_abc() {
+    let v = eval_js(r#"
+        ctx.resdata = { hex: Rivers.crypto.sha256("abc") };
+    "#).await;
+    assert_eq!(
+        v["hex"],
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+/// Bug 1: Rivers.crypto.sha256 — empty string vector (NIST FIPS 180-4).
+#[tokio::test]
+async fn rivers_crypto_sha256_known_vector_empty() {
+    let v = eval_js(r#"
+        ctx.resdata = { hex: Rivers.crypto.sha256("") };
+    "#).await;
+    assert_eq!(
+        v["hex"],
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+/// Bug 1: Rivers.crypto.sha512 — known SHA-512 vector for "abc" (NIST FIPS 180-4).
+#[tokio::test]
+async fn rivers_crypto_sha512_known_vector_abc() {
+    let v = eval_js(r#"
+        ctx.resdata = { hex: Rivers.crypto.sha512("abc") };
+    "#).await;
+    assert_eq!(
+        v["hex"],
+        "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a\
+2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+    );
+}
+
+/// Bug 1: Rivers.crypto.sha512 — empty string vector (NIST FIPS 180-4).
+#[tokio::test]
+async fn rivers_crypto_sha512_known_vector_empty() {
+    let v = eval_js(r#"
+        ctx.resdata = { hex: Rivers.crypto.sha512("") };
+    "#).await;
+    assert_eq!(
+        v["hex"],
+        "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce\
+47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    );
+}
+
 #[tokio::test]
 async fn rivers_crypto_timing_safe() {
     let v = eval_js(r#"
@@ -274,7 +324,8 @@ async fn all_spec_rivers_apis_exist() {
             "Rivers.log.info", "Rivers.log.warn", "Rivers.log.error",
             "Rivers.crypto.hashPassword", "Rivers.crypto.verifyPassword",
             "Rivers.crypto.randomHex", "Rivers.crypto.randomBase64url",
-            "Rivers.crypto.hmac", "Rivers.crypto.timingSafeEqual"
+            "Rivers.crypto.hmac", "Rivers.crypto.timingSafeEqual",
+            "Rivers.crypto.sha256", "Rivers.crypto.sha512"
         ];
         var ghosts = [];
         for (var i = 0; i < apis.length; i++) {

--- a/docs/guide/tutorials/tutorial-ts-handlers.md
+++ b/docs/guide/tutorials/tutorial-ts-handlers.md
@@ -106,6 +106,8 @@ declare const Rivers: {
         randomHex(bytes: number): string;
         randomBase64url(bytes: number): string;
         hmac(key: string, data: string): string;
+        sha256(input: string): string;
+        sha512(input: string): string;
         timingSafeEqual(a: string, b: string): boolean;
         encrypt(keyName: string, plaintext: string, options?: { aad?: string }): EncryptResult;
         decrypt(keyName: string, ciphertext: string, nonce: string, options: { key_version: number; aad?: string }): string;


### PR DESCRIPTION
## Summary
Adds two helper methods to the V8 isolate's \`Rivers.crypto\` namespace:

- \`sha256(input: string): string\` — lowercase hex-encoded SHA-256
- \`sha512(input: string): string\` — lowercase hex-encoded SHA-512

Closes the gap in \`docs/bugs/case-rivers-crypto-textencoder-gap.md\`. Without these helpers, handlers needing a deterministic SHA of an arbitrary string (API key fingerprints, content-addressed storage, webhook signature verification, idempotency keys) had no clean path — the workaround required misusing \`hmac\` with a placeholder "pepper" key.

## Implementation
Both callbacks mirror the existing \`hmac_callback\` exactly: same signature, same install pattern on \`crypto_obj\`, same error-handling style. \`sha2\` and \`hex\` crates were already deps.

## Tests (NIST FIPS 180-4 known vectors)
- \`sha256("")\` = \`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\`
- \`sha256("abc")\` = \`ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\`
- \`sha512("")\` = \`cf83e1357eefb8bd…d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e\`
- \`sha512("abc")\` = \`ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f\`

All 4 new tests pass; full \`v8_bridge_tests\` 29/29; \`cargo test -p riversd --lib\` 416/416 (no regressions).

## Tutorial
\`docs/guide/tutorials/tutorial-ts-handlers.md\` TS surface declaration extended to list both new methods.

## What this PR is NOT
- Not Option B (\`TextEncoder\`/\`TextDecoder\`). The bug filer explicitly chose Option A as the smaller surface.
- Not streaming hash APIs, byte-array variants, or any other crypto primitive. \`sha256(string)\` and \`sha512(string)\` cover the ~95% case the report describes.
- Not a change to existing \`hmac\` / \`hashPassword\` / \`encrypt\` callbacks.

## Version
\`just bump-patch\` per the (just-tightened) versioning policy: this closes a documented-but-missing helper, not new ground. \`0.55.0+1942260426\` → \`0.55.1+1947260426\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)