### PR TITLE
feat(mcp): CB-P1.9 — thread path_params into MCP dispatch handler context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.3+1500080526"
+version = "0.60.4+1514080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,50 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — CB-P1.9: thread `path_params` into MCP dispatch handler context
+
+**Decision:** When an MCP route is mounted with a templated path (e.g.
+`/mcp/builder/{projectId}`), the matched path variables now reach the
+codecomponent handler under `args.path_params`. Implementation threads the
+existing `MatchedRoute.path_params` (same shape REST uses) through
+`mcp::dispatch::dispatch` → `handle_tools_call` /
+`handle_tools_call_batch` → `dispatch_codecomponent_tool` and into the
+args JSON. Non-templated MCP routes pass an empty object so handlers can
+uniformly read `args.path_params.foo` without null guards.
+
+The args-building step was factored into `build_codecomponent_args`, a
+small pure function over `(arguments, auth_context, path_params)`. This
+made the wire-format unit-testable without spinning up V8 and codified
+the contract as a single named place rather than an inline json! macro
+buried in the dispatch function.
+
+**Why a separate field rather than merging into `request`:** keeping
+`path_params` distinct preserves the asymmetry CB called out — URL
+identifiers (defense-in-depth, e.g. `path.projectId == auth.projectId`)
+should be distinguishable from caller-supplied tool arguments. Merging
+them would make handler-side enforcement weaker (a caller could spoof
+`projectId` in `arguments`).
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `crates/riversd/src/mcp/dispatch.rs` | `dispatch`, `handle_tools_call`, `handle_tools_call_batch`, `dispatch_codecomponent_tool` all take `path_params: &HashMap<String, String>`. New pure helper `build_codecomponent_args(arguments, auth_context, path_params)`. Two unit tests. | CB-P1.9 | Additive — handlers ignoring the field continue to work. |
+| `crates/riversd/src/server/view_dispatch.rs` | Both MCP `dispatch()` call sites (batch + single) now pass `&matched.path_params`. | CB-P1.9 | `MatchedRoute.path_params` already populated by the router; just had to be threaded. |
+| `docs/arch/rivers-mcp-view-spec.md` §10.4 | New section documenting the handler args shape (`request` / `session` / `path_params`) for codecomponent-backed tools. | CB-P1.9 | Closes the documentation gap CB pointed out — the URL template was decorative for the handler. |
+
+**Spec reference:** `cb-rivers-feature-request.md` P1.9;
+`docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` Plan B.
+
+**Resolution method:** Read `MatchedRoute` (carries `path_params`),
+`execute_mcp_view`, `dispatch()` chain. Confirmed `path_params` was
+already extracted by the router but never threaded into the JSON-RPC
+dispatcher. Mirrored the REST contract. Picked the helper-function path
+over an inline `serde_json!` so the args shape is documented and tested
+in one place.
+
+---
+
 ## 2026-05-08 — CB-P1.13: capability propagation for MCP `view=` dispatch
 
 **Decision:** Extracted the REST primary-handler datasource-wiring loop

--- a/crates/riversd/src/mcp/dispatch.rs
+++ b/crates/riversd/src/mcp/dispatch.rs
@@ -35,6 +35,7 @@ pub async fn dispatch(
     auth_context: Option<&serde_json::Value>,
     session_id: Option<&str>,
     federation: &[McpFederationConfig],
+    path_params: &HashMap<String, String>,
 ) -> JsonRpcResponse {
     if req.jsonrpc != "2.0" {
         return JsonRpcResponse::invalid_request(req.id.clone());
@@ -51,7 +52,7 @@ pub async fn dispatch(
                 .unwrap_or("<unknown>")
                 .to_string();
             let tool_start = std::time::Instant::now();
-            let resp = handle_tools_call(req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id).await;
+            let resp = handle_tools_call(req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id, path_params).await;
             if let Some(ref bus) = ctx.audit_bus {
                 let is_error = resp.result.as_ref()
                     .and_then(|r| r.get("isError"))
@@ -66,7 +67,7 @@ pub async fn dispatch(
             }
             resp
         }
-        "tools/call_batch" => handle_tools_call_batch(req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id).await,
+        "tools/call_batch" => handle_tools_call_batch(req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id, path_params).await,
         "resources/list" => handle_resources_list(req, resources, federation).await,
         "resources/read" => handle_resources_read(req, resources, ctx, dv_namespace, app_id, federation).await,
         "resources/templates/list" => handle_resource_templates(req, resources, app_id),
@@ -215,6 +216,7 @@ async fn handle_tools_call(
     auth_context: Option<&serde_json::Value>,
     federation: &[McpFederationConfig],
     session_id: Option<&str>,
+    path_params: &HashMap<String, String>,
 ) -> JsonRpcResponse {
     let tool_name = match req.params.get("name").and_then(|n| n.as_str()) {
         Some(n) => n,
@@ -249,7 +251,7 @@ async fn handle_tools_call(
 
     // CB-P0.1: codecomponent-backed tools dispatch through the ProcessPool.
     if let Some(ref view_name) = tool_config.view {
-        return dispatch_codecomponent_tool(req, ctx, app_id, dv_namespace, view_name, arguments, auth_context, session_id).await;
+        return dispatch_codecomponent_tool(req, ctx, app_id, dv_namespace, view_name, arguments, auth_context, session_id, path_params).await;
     }
 
     let params: HashMap<String, QueryValue> = arguments.into_iter().map(|(k, v)| {
@@ -314,6 +316,7 @@ async fn handle_tools_call_batch(
     auth_context: Option<&serde_json::Value>,
     federation: &[McpFederationConfig],
     session_id: Option<&str>,
+    path_params: &HashMap<String, String>,
 ) -> JsonRpcResponse {
     let items = match req.params.get("items").and_then(|v| v.as_array()) {
         Some(arr) => arr.clone(),
@@ -361,7 +364,7 @@ async fn handle_tools_call_batch(
             }),
         };
 
-        let resp = handle_tools_call(&synthetic_req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id).await;
+        let resp = handle_tools_call(&synthetic_req, tools, ctx, app_id, dv_namespace, auth_context, federation, session_id, path_params).await;
 
         // A JSON-RPC error response (has `error` field, no `result`) is an item failure.
         if resp.error.is_some() {
@@ -403,6 +406,28 @@ async fn handle_tools_call_batch(
 /// `ctx.session`, and dispatches it through the default process pool. The handler
 /// receives its full capabilities (storage, driver_factory, dataview_executor, lockbox,
 /// keystore) via task_enrichment::enrich — identical to REST, WebSocket, and SSE handlers.
+/// Build the codecomponent handler's args object: tool arguments under
+/// `request`, resolved caller identity under `session`, and matched URL
+/// path variables under `path_params`. Pure function so the wire-format
+/// is unit-testable without spinning up V8.
+///
+/// `path_params` follows the same shape REST uses (`MatchedRoute.path_params`
+/// in `crates/riversd/src/server/view_dispatch.rs`) — keys are the segment
+/// names declared in the route template (e.g. `{projectId}` → key
+/// `projectId`). Empty for non-templated MCP routes; handlers ignoring the
+/// field continue to work unchanged. (CB-P1.9.)
+fn build_codecomponent_args(
+    arguments: serde_json::Map<String, serde_json::Value>,
+    auth_context: Option<&serde_json::Value>,
+    path_params: &HashMap<String, String>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "request": serde_json::Value::Object(arguments),
+        "session": auth_context,
+        "path_params": path_params,
+    })
+}
+
 async fn dispatch_codecomponent_tool(
     req: &JsonRpcRequest,
     ctx: &AppContext,
@@ -412,6 +437,7 @@ async fn dispatch_codecomponent_tool(
     arguments: serde_json::Map<String, serde_json::Value>,
     auth_context: Option<&serde_json::Value>,
     session_id: Option<&str>,
+    path_params: &HashMap<String, String>,
 ) -> JsonRpcResponse {
     use crate::process_pool::{Entrypoint, TaskContextBuilder, TaskKind};
     use rivers_runtime::view::HandlerConfig;
@@ -535,12 +561,9 @@ async fn dispatch_codecomponent_tool(
         }
     });
 
-    // Wrap tool arguments as ctx.request and propagate caller identity as ctx.session,
-    // matching the REST pipeline's injection pattern (pipeline.rs).
-    let args = serde_json::json!({
-        "request": serde_json::Value::Object(arguments),
-        "session": auth_context,
-    });
+    // CB-P1.9: build the args object (request + session + path_params) via a
+    // small helper so the shape is unit-testable without spinning up V8.
+    let args = build_codecomponent_args(arguments, auth_context, path_params);
 
     let builder = TaskContextBuilder::new()
         .entrypoint(entrypoint)
@@ -1220,6 +1243,44 @@ mod tests {
         });
         assert_eq!(entry["isError"], serde_json::json!(true));
         assert_eq!(entry["content"][0]["text"], serde_json::json!("Unknown tool: bad_tool"));
+    }
+
+    /// CB-P1.9: when the route template includes path variables, the matched
+    /// values must reach the codecomponent handler under `path_params` —
+    /// parity with the REST dispatch contract (`MatchedRoute.path_params`).
+    #[test]
+    fn build_codecomponent_args_threads_path_params() {
+        let mut arguments = serde_json::Map::new();
+        arguments.insert("query".into(), serde_json::json!("hello"));
+
+        let auth = serde_json::json!({"projectId": "P001", "role": "builder"});
+
+        let mut path_params = HashMap::new();
+        path_params.insert("projectId".into(), "P001".into());
+        path_params.insert("orgId".into(), "acme".into());
+
+        let args = build_codecomponent_args(arguments, Some(&auth), &path_params);
+
+        assert_eq!(args["request"]["query"], serde_json::json!("hello"));
+        assert_eq!(args["session"]["projectId"], serde_json::json!("P001"));
+        assert_eq!(args["session"]["role"], serde_json::json!("builder"));
+        assert_eq!(args["path_params"]["projectId"], serde_json::json!("P001"));
+        assert_eq!(args["path_params"]["orgId"], serde_json::json!("acme"));
+    }
+
+    /// CB-P1.9: non-templated MCP routes pass an empty `path_params` map.
+    /// Handlers that ignore the field continue to work; consumers that read
+    /// it see `{}` rather than `null` so `args.path_params.foo` is uniformly
+    /// safe to look up.
+    #[test]
+    fn build_codecomponent_args_empty_path_params_is_object_not_null() {
+        let arguments = serde_json::Map::new();
+        let path_params: HashMap<String, String> = HashMap::new();
+        let args = build_codecomponent_args(arguments, None, &path_params);
+        assert!(args["path_params"].is_object(),
+            "expected empty object for path_params, got {:?}", args["path_params"]);
+        assert_eq!(args["path_params"].as_object().map(|m| m.len()), Some(0));
+        assert!(args["session"].is_null(), "session should be null when no auth");
     }
 }
 

--- a/crates/riversd/src/server/view_dispatch.rs
+++ b/crates/riversd/src/server/view_dispatch.rs
@@ -703,7 +703,7 @@ async fn execute_mcp_view(
                         };
                         let resp = crate::mcp::dispatch::dispatch(
                             &ctx, &req, tools, resources, prompts, app_id, dv_namespace, app_dir, instructions,
-                            auth_context.as_ref(), session_id.as_deref(), federation,
+                            auth_context.as_ref(), session_id.as_deref(), federation, &matched.path_params,
                         ).await;
                         responses.push(serde_json::to_value(&resp).unwrap_or_default());
                     }
@@ -751,7 +751,7 @@ async fn execute_mcp_view(
 
                 let resp = crate::mcp::dispatch::dispatch(
                     &ctx, &req, tools, resources, prompts, app_id, dv_namespace, app_dir, instructions,
-                    auth_context.as_ref(), session_id.as_deref(), federation,
+                    auth_context.as_ref(), session_id.as_deref(), federation, &matched.path_params,
                 ).await;
 
                 // For initialize: create session (storing auth identity) and attach Mcp-Session-Id header

--- a/docs/arch/rivers-mcp-view-spec.md
+++ b/docs/arch/rivers-mcp-view-spec.md
@@ -522,6 +522,31 @@ Coercion failure returns JSON-RPC error `-32602` (Invalid params).
 | MCP-24 | Missing required parameters MUST be rejected with `-32602`. |
 | MCP-25 | Default values from parameter declarations apply when an optional argument is absent. |
 
+### 10.4 Codecomponent Handler Args (CB-P1.9)
+
+When a tool dispatches via `view = "..."` (codecomponent backend, §13.2), the
+handler's args object has the following shape:
+
+```json
+{
+  "request": { /* tool arguments — same as MCP tools/call `arguments` */ },
+  "session": { /* resolved caller identity, or null if no auth */ },
+  "path_params": { /* matched URL path variables, possibly empty */ }
+}
+```
+
+`path_params` mirrors REST's `MatchedRoute.path_params` exactly: keys are
+the segment names declared in the route template (e.g. mounting an MCP
+view at `/mcp/builder/{projectId}` puts the matched value under
+`path_params.projectId`). Non-templated routes pass an empty object —
+never `null` — so a handler that reads `args.path_params.foo` is uniformly
+safe.
+
+This enables defense-in-depth checks like `path.projectId ===
+auth.projectId` at the handler level, and lets MCP routes carry a
+project segment for log/dashboard clarity without losing handler-side
+enforcement.
+
 ---
 
 ## 11. Error Handling

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-05-08 — CB-P1.9: thread `path_params` into MCP dispatch handler context
+
+Closes the gap CB filed 2026-05-07: templated MCP routes
+(`/mcp/builder/{projectId}`) now deliver matched URL variables to
+codecomponent handlers under `args.path_params` — parity with the REST
+dispatch contract. Without this the URL template was decorative; the
+handler could not enforce `path.projectId == auth.projectId`.
+
+| File | Change | Spec ref | Notes |
+|------|--------|----------|-------|
+| `crates/riversd/src/mcp/dispatch.rs` | `dispatch`, `handle_tools_call`, `handle_tools_call_batch`, `dispatch_codecomponent_tool` all carry `path_params`. New pure helper `build_codecomponent_args(arguments, auth_context, path_params)` with 2 unit tests covering populated and empty path-params shapes. | CB-P1.9 | Empty-map default keeps non-templated routes additive — no handler change required. |
+| `crates/riversd/src/server/view_dispatch.rs` | MCP dispatch call sites pass `&matched.path_params`. | CB-P1.9 | `MatchedRoute.path_params` already populated by the router; threading only. |
+| `docs/arch/rivers-mcp-view-spec.md` §10.4 | New section documenting the codecomponent handler args shape. | CB-P1.9 | |
+| `Cargo.toml` (workspace) | Patch bump on top of 0.60.3. | CLAUDE.md versioning | |
+
+**Tests:** `cargo test -p riversd --lib` 476/476 + 7 ignored (was 474/474; 2 new).
+New unit tests:
+`mcp::dispatch::tests::build_codecomponent_args_threads_path_params`,
+`mcp::dispatch::tests::build_codecomponent_args_empty_path_params_is_object_not_null`.
+
+---
+
 ## 2026-05-08 — CB-P1.13: capability propagation for MCP `view=` dispatch
 
 Closes the gap CB filed 2026-05-08: MCP-dispatched codecomponent handlers


### PR DESCRIPTION
## Summary

- Templated MCP routes (`/mcp/builder/{projectId}`) now deliver matched URL variables to codecomponent handlers under `args.path_params` — parity with the REST dispatch contract. Without this the URL template was decorative; the handler couldn't enforce `path.projectId == auth.projectId`.
- Threaded `path_params` through `dispatch` → `handle_tools_call` / `handle_tools_call_batch` → `dispatch_codecomponent_tool`. `MatchedRoute.path_params` was already populated by the router; only the threading was missing.
- Extracted args-building into `build_codecomponent_args(arguments, auth_context, path_params)` so the wire-format is unit-testable without V8 and the contract lives in one named place. Empty-map default for non-templated routes (never `null`).

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` (Plan B).

## Test plan

- [x] `cargo test -p riversd --lib` — **476 passed** / 0 failed / 7 ignored (was 474; +2 new)
- [x] New unit tests:
  - `mcp::dispatch::tests::build_codecomponent_args_threads_path_params`
  - `mcp::dispatch::tests::build_codecomponent_args_empty_path_params_is_object_not_null`
- [x] Spec §10.4 added documenting the codecomponent handler args shape (`request` / `session` / `path_params`)
- [x] Version bumped to `0.60.4+1514080526`

🤖 Generated with [Claude Code](https://claude.com/claude-code)