### PR TITLE
feat(view): CB-P1.11 — per-view static response_headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.3+1500080526"
+version = "0.60.5+1526080526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.4+1514080526"
+version = "0.60.5+1526080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,69 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — CB-P1.11: per-view static `response_headers`
+
+**Decision:** Added `[api.views.*.response_headers]` as a first-class
+config field on `ApiViewConfig`. Static headers configured here are
+appended to every HTTP response from the view, after handler-set
+headers. Handler overrides win — a configured header is inserted only
+when the response does not already carry one with the same name. This
+satisfies CB's request for protocol-level deprecation signaling on the
+legacy `/api/mcp` route (`Deprecation` / `Sunset` / `Link` per RFC 8594)
+while preserving the existing handler-controlled-headers contract.
+
+**Why a single intercept in `combined_fallback_handler`:** Every view
+type — REST, WebSocket, SSE, MCP — flows through `view_dispatch_handler`
+and back out through `combined_fallback_handler`. Cloning
+`matched.config.response_headers` before moving `matched` into the
+dispatcher and applying the helper to the materialized `Response` after
+return covers all view types from one place. Avoiding per-view-type
+injection sites was the alternative considered and rejected: MCP alone
+has 9 distinct response paths, and each return would have needed its
+own header pass.
+
+**Why validation is in Layer 1 (structural):** Header name + value
+constraints are syntactic, not relational — they don't require the
+bundle to be loaded or other apps to be present. Catching reserved
+headers and malformed names at `riverpackage validate` time means
+`riversd` start-up never sees an unbuildable header.
+
+**Reserved set choice:**
+
+| Header | Why reserved |
+|---|---|
+| `Content-Type` | Set per response by the body serializer (JSON / SSE / markdown). User override would lie about the body. |
+| `Content-Length` | Set by axum's body builder; user override would desync. |
+| `Transfer-Encoding` | Connection-level concern; managed by the HTTP layer. |
+| `Mcp-Session-Id` | MCP protocol header set by `crate::mcp::session::create_session` on `initialize`. User override would corrupt session resumption. |
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `crates/rivers-runtime/src/view.rs` | New `response_headers: Option<HashMap<String, String>>` field on `ApiViewConfig`. | CB-P1.11 | Optional + `#[serde(default)]` so existing bundles deserialize unchanged. |
+| `crates/rivers-runtime/src/validate_structural.rs` | `response_headers` added to `VIEW_FIELDS` allowlist. New `validate_response_headers` helper invoked from `validate_view`. 3 unit tests covering reserved-name rejection, malformed name + non-printable value rejection, and a happy path. | CB-P1.11 | `S005` on each invalid entry — same code already used for "invalid value for field" so no new error code needed. |
+| `crates/rivers-runtime/src/{validate_existence,validate_crossref}.rs` | All `ApiViewConfig` test fixtures updated with `response_headers: None`. | CB-P1.11 | Mechanical follow-on of the new field. |
+| `crates/riversd/src/view_engine/response_headers.rs` (new) | `apply_static_response_headers` helper. 4 unit tests: applied-when-absent, handler-override-wins, no-op-when-config-is-none, malformed-entries-skipped. | CB-P1.11 | Dropped malformed entries with WARN rather than letting them propagate as 500s. |
+| `crates/riversd/src/view_engine/mod.rs` | Module wiring + re-export. | CB-P1.11 | |
+| `crates/riversd/src/server/view_dispatch.rs` | `combined_fallback_handler` clones `matched.config.response_headers` before moving `matched` and applies headers to the returned response. | CB-P1.11 | Single intercept covers all view types. |
+| `crates/riversd/src/{bundle_diff,bundle_loader/load,view_engine/mod}.rs` + tests | All `ApiViewConfig` literals updated. | CB-P1.11 | Mechanical. |
+| `docs/arch/rivers-view-layer-spec.md` §5.4 | New section documenting config shape, validation rules, runtime semantics, handler-override-wins precedence, and reserved-header rejection. | CB-P1.11 | |
+
+**Spec reference:** `cb-rivers-feature-request.md` P1.11;
+`docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` Plan C.
+
+**Resolution method:** Read CB's report (looking for protocol-level
+deprecation signaling — `Deprecation`/`Sunset` headers on the legacy
+`/api/mcp` route). Confirmed `[api.views.X.response_headers]` was
+silently dropped today (`unknown key` warning). Picked the single
+intercept site over per-view-type injection because every view goes
+through `view_dispatch_handler`. Picked handler-override-wins as
+default because handlers are the late-binding source of intent
+(per-request) while config is the early-binding source (per-deploy).
+
+---
+
 ## 2026-05-08 — CB-P1.9: thread `path_params` into MCP dispatch handler context
 
 **Decision:** When an MCP route is mounted with a templated path (e.g.

--- a/crates/rivers-runtime/src/validate_crossref.rs
+++ b/crates/rivers-runtime/src/validate_crossref.rs
@@ -1308,6 +1308,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         }
     }
 
@@ -1351,6 +1352,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         }
     }
 
@@ -1389,6 +1391,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         }
     }
 
@@ -2786,6 +2789,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         }
     }
 
@@ -3029,6 +3033,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         }
     }
 

--- a/crates/rivers-runtime/src/validate_existence.rs
+++ b/crates/rivers-runtime/src/validate_existence.rs
@@ -629,6 +629,7 @@ nopassword = true
                 instructions: None,
                 session: None,
                 federation: vec![],
+            response_headers: None,
             },
         );
     }
@@ -1120,6 +1121,7 @@ nopassword = true
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         };
         bundle.apps[0]
             .config
@@ -1189,6 +1191,7 @@ nopassword = true
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         };
         bundle.apps[0]
             .config
@@ -1269,6 +1272,7 @@ nopassword = true
             instructions: None,
             session: None,
             federation: vec![],
+            response_headers: None,
         };
         bundle.apps[0]
             .config

--- a/crates/rivers-runtime/src/validate_structural.rs
+++ b/crates/rivers-runtime/src/validate_structural.rs
@@ -105,6 +105,7 @@ const VIEW_FIELDS: &[&str] = &[
     "session_revalidation_interval_s", "polling", "event_handlers",
     "on_stream", "ws_hooks", "on_event",
     "tools", "resources", "prompts", "instructions", "session", "federation",
+    "response_headers",
 ];
 const VIEW_REQUIRED: &[&str] = &["path", "method", "view_type", "handler"];
 
@@ -841,6 +842,13 @@ fn validate_view(
         }
     }
 
+    // Validate [api.views.*.response_headers] (CB-P1.11).
+    // Names must be RFC 7230 tokens; values must be ASCII-printable; a small
+    // reserved set is rejected because the framework manages those headers.
+    if let Some(rh) = table.get("response_headers") {
+        validate_response_headers(rh, file, table_path, app_name, results);
+    }
+
     // Validate MCP resources sub-table (if present — MCP view type only).
     // S-MCP-2: warn when a resource has subscribable = true but view method is not GET.
     if let Some(resources_val) = table.get("resources") {
@@ -910,6 +918,116 @@ fn check_unknown_keys(
             }
 
             results.push(result);
+        }
+    }
+}
+
+/// Validate `[api.views.*.response_headers]` (CB-P1.11).
+///
+/// Rules:
+/// - Must be a TOML table.
+/// - Header names match RFC 7230 token grammar (alphanumerics + `-`).
+/// - Header values must be ASCII-printable (`\x20`–`\x7E`); no control chars.
+/// - Reserved framework-managed headers are rejected (case-insensitive):
+///   `Content-Type`, `Content-Length`, `Transfer-Encoding`, `Mcp-Session-Id`.
+fn validate_response_headers(
+    value: &toml::Value,
+    file: &str,
+    table_path: &str,
+    app_name: &str,
+    results: &mut Vec<ValidationResult>,
+) {
+    const RESERVED: &[&str] = &[
+        "content-type",
+        "content-length",
+        "transfer-encoding",
+        "mcp-session-id",
+    ];
+
+    let headers_path = format!("{}.response_headers", table_path);
+    let table = match value.as_table() {
+        Some(t) => t,
+        None => {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S004,
+                    file,
+                    format!("{} must be a table", headers_path),
+                )
+                .with_table_path(&headers_path)
+                .with_app(app_name),
+            );
+            return;
+        }
+    };
+
+    for (name, val) in table {
+        let name_lc = name.to_ascii_lowercase();
+        if RESERVED.iter().any(|r| *r == name_lc) {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "{}.\"{}\" is a framework-managed header and cannot be set via response_headers",
+                        headers_path, name
+                    ),
+                )
+                .with_table_path(&headers_path)
+                .with_field(name)
+                .with_app(app_name),
+            );
+            continue;
+        }
+        let name_ok = !name.is_empty()
+            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        if !name_ok {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "{}.\"{}\" is not a valid HTTP header name (alphanumerics and `-` only)",
+                        headers_path, name
+                    ),
+                )
+                .with_table_path(&headers_path)
+                .with_field(name)
+                .with_app(app_name),
+            );
+            continue;
+        }
+
+        let s = match val.as_str() {
+            Some(s) => s,
+            None => {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S004,
+                        file,
+                        format!("{}.\"{}\" must be a string", headers_path, name),
+                    )
+                    .with_table_path(&headers_path)
+                    .with_field(name)
+                    .with_app(app_name),
+                );
+                continue;
+            }
+        };
+        if !s.bytes().all(|b| (0x20..=0x7E).contains(&b)) {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "{}.\"{}\" contains non-printable or non-ASCII bytes; HTTP header values must be ASCII-printable",
+                        headers_path, name
+                    ),
+                )
+                .with_table_path(&headers_path)
+                .with_field(name)
+                .with_app(app_name),
+            );
         }
     }
 }
@@ -1654,6 +1772,125 @@ qeury = {limit = "limit"}
             .expect("expected S002 for unknown 'qeury' in parameter_mapping");
 
         assert!(fail.suggestion.as_ref().unwrap().contains("query"));
+    }
+
+    // ── CB-P1.11 response_headers validation ──────────────────────
+
+    #[test]
+    fn response_headers_rejects_reserved_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        std::fs::write(
+            bundle_dir.join("test-app/app.toml"),
+            r#"
+[data.dataviews.items]
+name       = "items"
+datasource = "data"
+
+[api.views.items]
+path       = "items"
+method     = "GET"
+view_type  = "Rest"
+auth       = "none"
+
+[api.views.items.handler]
+type     = "dataview"
+dataview = "items"
+
+[api.views.items.response_headers]
+"Deprecation"  = "true"
+"content-type" = "application/json"
+"Mcp-Session-Id" = "abc"
+"#,
+        )
+        .unwrap();
+        let results = validate_structural(&bundle_dir);
+        let bad: Vec<_> = results.iter()
+            .filter(|r| r.error_code.as_deref() == Some("S005")
+                && r.message.contains("framework-managed"))
+            .collect();
+        assert_eq!(bad.len(), 2,
+            "expected S005 on both reserved headers, got {}: {:?}",
+            bad.len(),
+            results.iter().map(|r| (&r.error_code, &r.message)).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn response_headers_rejects_invalid_name_and_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        std::fs::write(
+            bundle_dir.join("test-app/app.toml"),
+            r#"
+[data.dataviews.items]
+name       = "items"
+datasource = "data"
+
+[api.views.items]
+path       = "items"
+method     = "GET"
+view_type  = "Rest"
+auth       = "none"
+
+[api.views.items.handler]
+type     = "dataview"
+dataview = "items"
+
+[api.views.items.response_headers]
+"Bad Name" = "ok"
+"X-Bell" = "\u0007warn"
+"#,
+        )
+        .unwrap();
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r| r.error_code.as_deref() == Some("S005")
+            && r.message.contains("not a valid HTTP header name")),
+            "expected S005 for invalid header name (Bad Name)");
+        assert!(results.iter().any(|r| r.error_code.as_deref() == Some("S005")
+            && r.message.contains("non-printable")),
+            "expected S005 for non-printable header value (X-Bell)");
+    }
+
+    #[test]
+    fn response_headers_accepts_valid_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        std::fs::write(
+            bundle_dir.join("test-app/app.toml"),
+            r#"
+[data.dataviews.items]
+name       = "items"
+datasource = "data"
+
+[api.views.items]
+path       = "items"
+method     = "GET"
+view_type  = "Rest"
+auth       = "none"
+
+[api.views.items.handler]
+type     = "dataview"
+dataview = "items"
+
+[api.views.items.response_headers]
+"Deprecation" = "true"
+"Sunset"      = "Wed, 31 Dec 2026 23:59:59 GMT"
+"Cache-Control" = "max-age=60"
+"#,
+        )
+        .unwrap();
+        let results = validate_structural(&bundle_dir);
+        let view_failures: Vec<_> = results.iter()
+            .filter(|r| r.status == ValidationStatus::Fail
+                && r.table_path.as_deref()
+                    .map(|p| p.contains("response_headers"))
+                    .unwrap_or(false))
+            .collect();
+        assert!(view_failures.is_empty(),
+            "expected no failures on valid response_headers, got: {:?}",
+            view_failures.iter().map(|r| (&r.error_code, &r.message)).collect::<Vec<_>>(),
+        );
     }
 
     // ── Multiple errors collected ─────────────────────────────────

--- a/crates/rivers-runtime/src/view.rs
+++ b/crates/rivers-runtime/src/view.rs
@@ -140,6 +140,15 @@ pub struct ApiViewConfig {
     /// into this server's `tools/list` and `resources/list` under a namespaced prefix.
     #[serde(default)]
     pub federation: Vec<McpFederationConfig>,
+
+    /// Static response headers added to every HTTP response from this view.
+    ///
+    /// Applied after handler-set headers — handler overrides win when the
+    /// same name is set on both sides. Reserved headers (`Content-Type`,
+    /// `Content-Length`, `Transfer-Encoding`, `Mcp-Session-Id`) are rejected
+    /// at structural validation time. CB-P1.11.
+    #[serde(default)]
+    pub response_headers: Option<HashMap<String, String>>,
 }
 
 /// Guard lifecycle hooks — all optional, all side-effects only.

--- a/crates/riversd/src/bundle_diff.rs
+++ b/crates/riversd/src/bundle_diff.rs
@@ -324,6 +324,7 @@ mod tests {
                 instructions: None,
                 session: None,
                 federation: vec![],
+        response_headers: None,
             });
         }
 

--- a/crates/riversd/src/server/view_dispatch.rs
+++ b/crates/riversd/src/server/view_dispatch.rs
@@ -72,7 +72,16 @@ pub(super) async fn combined_fallback_handler(
     }; // read lock dropped here
 
     if let Some(matched) = matched {
-        return view_dispatch_handler(State(ctx), request, matched).await.into_response();
+        // CB-P1.11: clone the static response_headers config before `matched`
+        // is moved into the handler, then apply them to the materialized
+        // response. Single intercept point covers REST + MCP + SSE/WS — every
+        // view type goes through this branch.
+        let static_headers = matched.config.response_headers.clone();
+        let mut response = view_dispatch_handler(State(ctx), request, matched)
+            .await
+            .into_response();
+        crate::view_engine::apply_static_response_headers(&mut response, static_headers.as_ref());
+        return response;
     }
 
     // Check if request path matches a failed app — return 503 with driver info

--- a/crates/riversd/src/view_engine/mod.rs
+++ b/crates/riversd/src/view_engine/mod.rs
@@ -3,11 +3,13 @@
 //! Per `rivers-view-layer-spec.md` §1-5, §12-13.
 
 mod pipeline;
+mod response_headers;
 mod router;
 mod types;
 mod validation;
 
 pub use pipeline::*;
+pub use response_headers::apply_static_response_headers;
 pub use router::*;
 pub use types::*;
 pub use validation::*;
@@ -73,6 +75,7 @@ mod tests {
             instructions: None,
             session: None,
             federation: vec![],
+        response_headers: None,
         }
     }
 

--- a/crates/riversd/src/view_engine/response_headers.rs
+++ b/crates/riversd/src/view_engine/response_headers.rs
@@ -1,0 +1,133 @@
+//! Static response-header injection for views (CB-P1.11).
+//!
+//! Configured via `[api.views.*.response_headers]`. Validation rejects
+//! malformed names, non-printable values, and a small reserved set
+//! (`Content-Type`, `Content-Length`, `Transfer-Encoding`,
+//! `Mcp-Session-Id`) at bundle-load time, so by the time
+//! [`apply_static_response_headers`] runs every entry is well-formed.
+//!
+//! Precedence: handler-set headers win. The framework only inserts a
+//! configured header when the response does not already carry it.
+
+use std::collections::HashMap;
+
+use axum::http::{HeaderName, HeaderValue};
+use axum::response::Response;
+
+/// Append per-view static headers to `response`, preserving any
+/// handler-set headers of the same name.
+///
+/// `config_headers` is `None` when the view has no `response_headers`
+/// table — in that case the function is a no-op. Keys / values that
+/// somehow fail axum's parser at runtime (e.g. survived structural
+/// validation but trip a tighter check) are skipped with a WARN log
+/// rather than dropping the response — failure to set a deprecation
+/// header should not turn a 200 into a 500.
+pub fn apply_static_response_headers(
+    response: &mut Response,
+    config_headers: Option<&HashMap<String, String>>,
+) {
+    let Some(map) = config_headers else { return };
+    let headers = response.headers_mut();
+    for (name, value) in map {
+        let parsed_name = match HeaderName::try_from(name.as_str()) {
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(
+                    header = %name,
+                    error = %err,
+                    "view response_headers: invalid header name at runtime — skipped",
+                );
+                continue;
+            }
+        };
+        if headers.contains_key(&parsed_name) {
+            // Handler override wins.
+            continue;
+        }
+        let parsed_value = match HeaderValue::try_from(value.as_str()) {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::warn!(
+                    header = %name,
+                    error = %err,
+                    "view response_headers: invalid header value at runtime — skipped",
+                );
+                continue;
+            }
+        };
+        headers.insert(parsed_name, parsed_value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    fn make_response_with_headers(initial: &[(&str, &str)]) -> Response {
+        let mut builder = Response::builder().status(200);
+        for (k, v) in initial {
+            builder = builder.header(*k, *v);
+        }
+        builder.body(Body::empty()).unwrap()
+    }
+
+    /// CB-P1.11: configured headers are applied to a response that does
+    /// not already carry them.
+    #[test]
+    fn applies_configured_headers_when_absent() {
+        let mut resp = make_response_with_headers(&[]);
+        let mut cfg = HashMap::new();
+        cfg.insert("Deprecation".into(), "true".into());
+        cfg.insert("Sunset".into(), "Wed, 31 Dec 2026 23:59:59 GMT".into());
+        apply_static_response_headers(&mut resp, Some(&cfg));
+        assert_eq!(resp.headers().get("deprecation").unwrap(), "true");
+        assert_eq!(
+            resp.headers().get("sunset").unwrap(),
+            "Wed, 31 Dec 2026 23:59:59 GMT",
+        );
+    }
+
+    /// CB-P1.11: handler-set headers win when both sides set the same name.
+    #[test]
+    fn handler_override_wins() {
+        let mut resp = make_response_with_headers(&[("cache-control", "no-store")]);
+        let mut cfg = HashMap::new();
+        cfg.insert("Cache-Control".into(), "max-age=60".into());
+        apply_static_response_headers(&mut resp, Some(&cfg));
+        assert_eq!(
+            resp.headers().get("cache-control").unwrap(),
+            "no-store",
+            "handler-set value must not be overwritten by config",
+        );
+        // Exactly one cache-control header should be present.
+        assert_eq!(resp.headers().get_all("cache-control").iter().count(), 1);
+    }
+
+    /// CB-P1.11: missing config table is a safe no-op.
+    #[test]
+    fn no_op_when_config_is_none() {
+        let mut resp = make_response_with_headers(&[("x-existing", "1")]);
+        apply_static_response_headers(&mut resp, None);
+        assert_eq!(resp.headers().get("x-existing").unwrap(), "1");
+        assert_eq!(resp.headers().len(), 1);
+    }
+
+    /// Defense-in-depth: even though structural validation rejects them,
+    /// the runtime helper must not panic on malformed entries that somehow
+    /// reach it — it skips and logs.
+    #[test]
+    fn malformed_entries_are_skipped_not_panicking() {
+        let mut resp = make_response_with_headers(&[]);
+        let mut cfg = HashMap::new();
+        cfg.insert("Bad Name With Spaces".into(), "ok".into());
+        cfg.insert("Valid".into(), "value\nwith-newline".into());
+        cfg.insert("X-Ok".into(), "ok".into());
+        apply_static_response_headers(&mut resp, Some(&cfg));
+        // Only the valid entry should make it through.
+        assert_eq!(resp.headers().get("x-ok").unwrap(), "ok");
+        assert!(resp.headers().get("bad name with spaces").is_none());
+        assert!(resp.headers().get("valid").is_none());
+    }
+}

--- a/crates/riversd/tests/graphql_common/mod.rs
+++ b/crates/riversd/tests/graphql_common/mod.rs
@@ -49,5 +49,6 @@ pub fn default_view_config() -> ApiViewConfig {
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }

--- a/crates/riversd/tests/guard_csrf_tests.rs
+++ b/crates/riversd/tests/guard_csrf_tests.rs
@@ -51,6 +51,7 @@ fn make_view(view_type: &str, guard: bool, auth: Option<&str>) -> ApiViewConfig 
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 
@@ -91,6 +92,7 @@ fn make_dataview_view() -> ApiViewConfig {
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 

--- a/crates/riversd/tests/message_consumer_tests.rs
+++ b/crates/riversd/tests/message_consumer_tests.rs
@@ -51,6 +51,7 @@ fn consumer_view(topic: &str, handler: &str) -> ApiViewConfig {
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 

--- a/crates/riversd/tests/pipeline_tests.rs
+++ b/crates/riversd/tests/pipeline_tests.rs
@@ -72,6 +72,7 @@ fn rest_view_with_handlers(
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 
@@ -111,6 +112,7 @@ fn none_handler_view(event_handlers: Option<ViewEventHandlers>) -> ApiViewConfig
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 

--- a/crates/riversd/tests/view_engine_tests.rs
+++ b/crates/riversd/tests/view_engine_tests.rs
@@ -45,6 +45,7 @@ fn rest_view(method: &str, path: &str, dataview: &str) -> ApiViewConfig {
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 
@@ -88,6 +89,7 @@ fn codecomponent_view(method: &str, path: &str) -> ApiViewConfig {
         instructions: None,
         session: None,
         federation: vec![],
+        response_headers: None,
     }
 }
 

--- a/docs/arch/rivers-view-layer-spec.md
+++ b/docs/arch/rivers-view-layer-spec.md
@@ -326,6 +326,41 @@ For DataView handlers, parameter mapping is declared explicitly in config — ea
 
 The final value in `ctx.sources["primary"]` after all pipeline stages is serialized to JSON and returned. Status code is 200 by default. CodeComponent handlers can return explicit `{ status, headers, body }` envelopes. DataView handlers always return 200 with the `QueryResult` rows serialized.
 
+### 5.4 Static response headers (CB-P1.11)
+
+Every view type — REST, WebSocket, SSE, MCP — supports an optional
+`[api.views.*.response_headers]` table. Entries are appended to every
+HTTP response from the view after handler-set headers; **handler
+overrides win** when the same name is set on both sides.
+
+```toml
+[api.views.legacy_mcp.response_headers]
+"Deprecation" = "true"
+"Sunset"      = "Wed, 31 Dec 2026 23:59:59 GMT"
+"Link"        = "</mcp/advisor>; rel=\"successor-version\""
+```
+
+**Validation rules** (Layer 1, structural):
+
+- Header names match RFC 7230 token grammar: alphanumerics + `-`.
+- Header values must be ASCII-printable (`\x20`–`\x7E`); no control
+  characters.
+- The framework manages four header names — they are rejected at
+  bundle-load time with `S005`: `Content-Type`, `Content-Length`,
+  `Transfer-Encoding`, `Mcp-Session-Id`.
+
+**Runtime semantics:**
+
+- Applied in `combined_fallback_handler` once per request — the same
+  intercept point covers all view types.
+- A configured header is inserted only if the response does not already
+  carry one with the same name (case-insensitive). This preserves
+  handler intent: if a handler sets `Cache-Control: no-store`, a
+  configured `Cache-Control: max-age=60` is dropped.
+- Defense-in-depth: any entry that survives validation but trips axum's
+  stricter runtime parser is logged at WARN and skipped — failure to
+  attach a deprecation header never turns a 200 into a 500.
+
 ---
 
 ## 6. WebSocket Views

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2026-05-08 — CB-P1.11: per-view static `response_headers`
+
+Closes the gap CB filed 2026-05-08: `[api.views.*.response_headers]`
+is now a first-class config field. CB can attach `Deprecation` /
+`Sunset` / `Link` headers (RFC 8594) to legacy MCP routes for
+protocol-level deprecation signaling, and `Cache-Control` to
+read-heavy DataView responses. Handler-set headers always win when
+both sides set the same name.
+
+| File | Change | Spec ref | Notes |
+|------|--------|----------|-------|
+| `crates/rivers-runtime/src/view.rs` | New `response_headers: Option<HashMap<String, String>>` on `ApiViewConfig`. | CB-P1.11 | Optional, `#[serde(default)]`. |
+| `crates/rivers-runtime/src/validate_structural.rs` | Allowlist + new `validate_response_headers`. Rejects reserved names (`Content-Type`, `Content-Length`, `Transfer-Encoding`, `Mcp-Session-Id`), malformed names (non-token chars), and non-printable values. 3 unit tests. | CB-P1.11 | `S005` on each. |
+| `crates/riversd/src/view_engine/response_headers.rs` (new) | `apply_static_response_headers(response, config)` helper. 4 unit tests. | CB-P1.11 | Handler-override-wins precedence. Defense-in-depth: malformed entries that survive validation get logged + skipped. |
+| `crates/riversd/src/server/view_dispatch.rs` | `combined_fallback_handler` clones config + applies after dispatch. | CB-P1.11 | Single intercept — covers REST/WS/SSE/MCP. |
+| `docs/arch/rivers-view-layer-spec.md` §5.4 | New section. | CB-P1.11 | |
+| `Cargo.toml` (workspace) | Patch bump. | CLAUDE.md versioning | |
+
+**Tests:** `cargo test -p riversd --lib` 480/480 (was 476; +4).
+`cargo test -p rivers-runtime --lib` 243/243 (was 240; +3).
+
+**Mechanical follow-on:** `response_headers: None` added to every
+`ApiViewConfig` literal across the workspace (test fixtures, bundle
+loader, bundle diff). No behavior change in those sites.
+
+---
+
 ## 2026-05-08 — CB-P1.9: thread `path_params` into MCP dispatch handler context
 
 Closes the gap CB filed 2026-05-07: templated MCP routes


### PR DESCRIPTION
## Summary

- `[api.views.*.response_headers]` is now a first-class config field on every view type. Configured headers are appended to the response after handler-set headers; **handler overrides win** when both sides set the same name. CB can attach `Deprecation` / `Sunset` / `Link` headers (RFC 8594) to legacy MCP routes for protocol-level deprecation signaling.
- Validation (Layer 1) rejects framework-managed reserved names (`Content-Type`, `Content-Length`, `Transfer-Encoding`, `Mcp-Session-Id`) plus malformed names (RFC 7230 token grammar) and non-printable values, all with `S005`.
- Single intercept point: `combined_fallback_handler` clones the config before moving `matched` into the view dispatcher and applies the helper to the materialized response. Covers REST/WS/SSE/MCP from one place — no per-view-type injection sites.
- Defense-in-depth: malformed entries that somehow survive validation get logged at WARN and skipped at runtime — failure to set a deprecation header never turns a 200 into a 500.

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` (Plan C).

## Test plan

- [x] `cargo test -p riversd --lib` — **480 passed** / 0 failed / 7 ignored (was 476; +4 on `view_engine::response_headers::tests`)
- [x] `cargo test -p rivers-runtime --lib` — **243 passed** / 0 failed (was 240; +3 on `validate_structural::tests::response_headers_*`)
- [x] Spec section added at `rivers-view-layer-spec.md` §5.4
- [x] Version bumped to `0.60.5+1526080526`
- [x] Mechanical follow-on: `response_headers: None` added to every `ApiViewConfig` literal across the workspace (test fixtures, bundle loader, bundle diff). No behavior change in those sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)