### PR TITLE
docs: CB-P1.12 closed as superseded by CB-P1.10 — bearer-via-named-guard recipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,41 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — CB-P1.12: closed as superseded by CB-P1.10 (docs only)
+
+**Decision:** No first-class `auth = "bearer"` view mode. CB-P1.10
+named guards (shipped earlier today as PR #103) already provide the
+enforcement boundary; a small codecomponent attached as `guard_view`
+gives operators full control over the lookup table, hash algorithm,
+identity claims projection, and audit fields without freezing any of
+those into framework config.
+
+**Why doc-only:** Every config knob a `auth = "bearer"` mode would need
+to expose (table name, hash column, hash algorithm, where-clause,
+claims projection, last-used update) is a one-liner inside the
+codecomponent. Adding the framework concept would have multiplied
+config surface for less flexibility than the recipe already delivers.
+This was the same conclusion CB drew in their own filing — "subsumed
+if P1.10 ships."
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `docs/arch/rivers-auth-session-spec.md` §11.5 | New "Bearer-token authentication via a named guard" recipe — TOML config, TypeScript handler, design rationale table comparing the recipe to a hypothetical `auth = "bearer"` mode, and operational notes. | CB-P1.12 (closed) | Documents the canonical shape so bundles converge on one pattern. |
+| `docs/arch/rivers-auth-session-spec.md` Appendix | New "Superseded asks" section recording CB-P1.12 as closed 2026-05-08 with a pointer to §11.5. | CB-P1.12 (closed) | |
+| `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` Plan E | Marked done; tasks E.1/E.2 ticked. | CB-P1.12 (closed) | |
+
+**Spec reference:** `cb-rivers-feature-request.md` P1.12;
+`docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` Plan E.
+
+**Resolution method:** Wrote the recipe + design table as the
+single-source-of-truth answer. Treated this as a doc-only change
+because the runtime primitive shipped in PR #103 already satisfies
+the use case end-to-end.
+
+---
+
 ## 2026-05-08 — CB-P1.10: per-view named guards (`guard_view`)
 
 **Decision:** Added `guard_view: Option<String>` as a new field on

--- a/docs/arch/rivers-auth-session-spec.md
+++ b/docs/arch/rivers-auth-session-spec.md
@@ -811,3 +811,120 @@ async function logout(req: Rivers.Request): Promise<Rivers.Response> {
 ```
 
 `Rivers.session.destroy()` deletes from StorageEngine and instructs Rivers to clear the session cookie on the response. Client is redirected to the login page with no active session.
+
+### 11.5 Bearer-token authentication via a named guard (CB-P1.10 / closes P1.12)
+
+When a route needs `Authorization: Bearer <token>` validation rather
+than the cookie-session model — typical for MCP routes, machine-to-machine
+APIs, and CLI clients — the sanctioned shape is a small codecomponent
+attached as a per-view named guard (see §3 + `rivers-mcp-view-spec.md`
+§13.5). This recipe replaces the previously-considered first-class
+`auth = "bearer"` mode (CB-P1.12): the named-guard primitive already
+provides the same enforcement boundary with no new framework concept.
+
+```toml
+# The bearer-validating guard view.
+[api.views.api_key_guard]
+view_type = "Rest"
+path      = "/internal/api-key-guard"
+method    = "POST"
+auth      = "none"
+
+[api.views.api_key_guard.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "handlers/auth.ts"
+entrypoint = "validate_api_key"
+resources  = ["app_db"]
+
+# The protected MCP route — references the guard by name.
+[api.views.mcp_advisor]
+view_type  = "Mcp"
+path       = "/mcp/advisor"
+method     = "POST"
+guard_view = "api_key_guard"
+```
+
+```typescript
+import { sha256 } from "rivers/crypto";
+
+interface ApiKeyClaims {
+    user_id: string;
+    role: string;
+    project_id: string | null;
+}
+
+export async function validate_api_key(req: Rivers.Request) {
+    const auth = (req.headers["authorization"] ?? "").trim();
+    const prefix = "Bearer ";
+    if (!auth.startsWith(prefix)) {
+        return { allow: false };
+    }
+    const token = auth.slice(prefix.length).trim();
+    if (token.length === 0) {
+        return { allow: false };
+    }
+
+    // Match against the hash, never the raw token.
+    const key_hash = sha256(token);
+    const rows = Rivers.db.query("app_db", `
+        SELECT created_by AS user_id, role, project_id
+        FROM api_keys
+        WHERE key_hash = ?
+          AND revoked_at IS NULL
+        LIMIT 1
+    `, [key_hash]);
+
+    if (rows.length === 0) {
+        return { allow: false };
+    }
+    const claims: ApiKeyClaims = rows[0] as ApiKeyClaims;
+
+    // Optional audit: stamp last-used. Best-effort — don't fail auth if
+    // the audit write errors.
+    try {
+        Rivers.db.execute("app_db",
+            "UPDATE api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE key_hash = ?",
+            [key_hash]);
+    } catch (_e) { /* swallow — audit is non-load-bearing */ }
+
+    return { allow: true, session_claims: claims };
+}
+```
+
+**Why this design rather than a first-class `auth = "bearer"` mode:**
+
+| Concern | Named-guard recipe | Hypothetical `auth = "bearer"` |
+|---|---|---|
+| Lookup table | bundle's own SQL | framework hard-codes `api_keys` schema |
+| Hash algorithm | bundle's choice | framework freezes one |
+| Identity claims | bundle's choice (any SQL projection) | framework's fixed shape |
+| Audit fields (`last_used_at`, etc.) | bundle's choice | framework would need config knobs |
+| Multi-role enforcement | `WHERE role = ?` in the SQL | needs additional config knob |
+| Cross-project bindings | composable in SQL | needs configurable predicate |
+
+Every dimension a hypothetical `auth = "bearer"` would expose as config
+(table name, hash column, hash algorithm, where-clause, claims
+projection, audit update) is already a one-liner inside the
+codecomponent. The named guard is the lower-config, higher-flexibility
+shape.
+
+**Operational notes:**
+
+- The guard codecomponent runs synchronously before JSON-RPC dispatch
+  on MCP views (and before REST handler dispatch once `guard_view` is
+  honoured by other view types — tracked follow-up). Keep the handler
+  fast — it is on the hot path.
+- The framework rejects with HTTP 401 + trace ID on `allow: false` or
+  any dispatcher error. Auth fails closed.
+- Per `rivers-mcp-view-spec.md` §13.5, the body is *not* yet parsed
+  when the guard runs. The guard cannot inspect tool arguments —
+  design for authentication-shape decisions only.
+
+---
+
+## Appendix — superseded asks
+
+- **CB-P1.12 — `auth = "bearer"` mode (closed 2026-05-08).** Subsumed
+  by CB-P1.10 named guards (§11.5 above). No framework change planned;
+  the recipe is the recommended shape for bearer enforcement.

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2026-05-08 — CB-P1.12: closed as superseded by CB-P1.10 (docs only)
+
+`auth = "bearer"` will not ship as a first-class view mode. CB-P1.10
+named guards (PR #103) already deliver the enforcement boundary; a
+small codecomponent attached as `guard_view` gives operators full
+control over the lookup table, hash algorithm, identity claims, and
+audit fields without freezing any of those into framework config —
+strictly more flexibility than a built-in mode could expose.
+
+| File | Change | Spec ref |
+|------|--------|----------|
+| `docs/arch/rivers-auth-session-spec.md` §11.5 | New "Bearer-token authentication via a named guard" recipe (TOML + TypeScript handler + design rationale table + operational notes). | CB-P1.12 (closed) |
+| `docs/arch/rivers-auth-session-spec.md` Appendix | New "Superseded asks" section pointing CB-P1.12 readers at §11.5. | CB-P1.12 (closed) |
+| `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` | Plan E marked done. | |
+
+**No code change. No version bump** — pure documentation.
+
+---
+
 ## 2026-05-08 — CB-P1.10: per-view named guards (`guard_view`)
 
 Closes the long-standing gap between `rivers-mcp-view-spec.md` (which


### PR DESCRIPTION
## Summary

- CB-P1.12 (`auth = "bearer"` view mode) won't ship as a first-class framework concept. PR #103's named guards (CB-P1.10) already deliver the enforcement boundary; a small codecomponent attached as `guard_view` gives operators full control over the lookup table, hash algorithm, identity claims, and audit fields without freezing any of those into framework config.
- Adds [rivers-auth-session-spec.md](docs/arch/rivers-auth-session-spec.md) §11.5 — "Bearer-token authentication via a named guard" — with TOML config, TypeScript handler, design-rationale table comparing the recipe to a hypothetical `auth = "bearer"` mode, and operational notes.
- Adds an "Appendix — Superseded asks" section recording CB-P1.12 closed 2026-05-08.
- No code change. Build-stamp-only bump.

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` (Plan E).

## Test plan

- [x] No code paths touched — existing test suites unchanged.
- [x] Build-stamp version bump: `0.60.6+1539080526 → 0.60.6+1545080526`.
- [x] Decision log + changelog entries cite CB-P1.12 closure rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)