### PR TITLE
feat(mcp): CB-P0.2 (full) — convention-based input_schema discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.6+1539080526"
+version = "0.60.6+1545080526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,86 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — CB-P0.2 (full): convention-based `input_schema` discovery for codecomponent MCP tools
+
+**Decision:** Codecomponent-backed MCP tools that don't declare an
+explicit `input_schema = "..."` are now auto-discovered from the
+conventional path `<app_dir>/schemas/<tool_name>.input.json`. Existing
+explicit declarations continue to work and take precedence; existing
+bundles with neither file get the open-object fallback unchanged.
+
+The discovery happens in `handle_tools_list` via a new pure helper
+`resolve_codecomponent_input_schema(tool_name, config_path, app_dir)`
+that codifies a three-tier lookup: explicit > conventional > open.
+
+**Why convention over a Rust-native TS-type extractor (deferred):**
+
+A from-scratch TypeScript-type → JSON-Schema transformer in Rust is a
+genuine project (the npm `ts-json-schema-generator` is ~10K LOC and
+covers a long tail of generics, conditional types, recursive types, and
+mapped types). Bundling it into `riverpackage` would balloon the crate
+size and would still ship a less-mature implementation than what npm
+already provides. Convention-based discovery delivers the
+single-source-of-truth half of the original P0.2 ask (no TOML
+duplication for every tool) without committing to a multi-month
+implementation effort. Bundle authors run the existing npm tool once
+per type, write to the conventional path, and `tools/list` picks it up
+automatically.
+
+The spec section now documents this as the recommended workflow with a
+worked `npx ts-json-schema-generator` invocation. The eventual
+Rust-native generator can land later without breaking the convention —
+it would write to the same paths.
+
+**Why explicit overrides convention rather than the reverse:** The
+explicit `input_schema = "..."` line is an author statement of intent.
+A bundle that declares an explicit path expects that file to be
+authoritative even if a conventional file happens to exist (e.g. left
+over from a rename). Inverting the precedence would silently break
+that contract.
+
+**Why malformed conventional files are silent fallbacks rather than
+errors:** Bundle authors edit schemas in place during development.
+Failing `tools/list` because a half-written schema doesn't parse would
+make the development loop painful and would also leak file-format
+details into the MCP wire response. The runtime falls back to the open
+object schema and continues serving; structural validation
+(`riverpackage validate`) is the place where malformed schemas should
+be caught.
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `crates/riversd/src/mcp/dispatch.rs` | New `resolve_codecomponent_input_schema` helper. `handle_tools_list` delegates to it. 5 unit tests covering explicit, conventional, explicit-overrides-conventional, missing both, and malformed-conventional cases. | CB-P0.2 | Pure function — testable without spinning up V8 or the dispatcher. |
+| `docs/arch/rivers-mcp-view-spec.md` §4.1.1 | New section documenting the three-tier resolution (explicit → conventional → open) and the recommended `ts-json-schema-generator` workflow. | CB-P0.2 | Closes the documentation gap CB referenced — the convention is now explicit, not folklore. |
+
+**Spec reference:** `cb-rivers-feature-request.md` P0.2;
+`docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` Plan F.
+
+**Resolution method:** Read CB's report (the original ask was
+"derive `inputSchema` from the codecomponent's TypeScript types"). The
+P0.2.c partial fix shipped explicit JSON Schema files. The remaining
+half — eliminating the TOML duplication of `input_schema = "..."` for
+every tool — was achievable as a small-footprint convention with no
+new framework concept. Picked this scope rather than the larger
+TS-type extractor because: (1) the npm tool already exists and is
+well-maintained, (2) the convention delivers SSoT today, and (3) the
+file location is the same either way, so a future Rust-native
+generator slots in without breaking bundles.
+
+**What this leaves on the table for a follow-up:**
+
+- A Rust-native TS-type extractor in `riverpackage` (e.g.
+  `riverpackage gen-schemas`) to remove the npm dependency entirely.
+  Worth doing if/when bundle authors push for it; the convention
+  established here is the integration point.
+- Cross-validation that the schema's properties match the handler's
+  declared TS request type. Requires SWC integration in `riverpackage`
+  (not currently linked there). Defer until there's reported friction.
+
+---
+
 ## 2026-05-08 — CB-P1.12: closed as superseded by CB-P1.10 (docs only)
 
 **Decision:** No first-class `auth = "bearer"` view mode. CB-P1.10

--- a/crates/riversd/src/mcp/dispatch.rs
+++ b/crates/riversd/src/mcp/dispatch.rs
@@ -158,18 +158,12 @@ async fn handle_tools_list(
     let mut tool_list: Vec<serde_json::Value> = tools.iter().map(|(name, config)| {
         let schema = if config.view.is_some() {
             // CB-P0.2.c: load explicit JSON Schema file when declared.
-            if let Some(schema_path) = &config.input_schema {
-                let full_path = app_dir.join(schema_path);
-                match std::fs::read_to_string(&full_path)
-                    .ok()
-                    .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-                {
-                    Some(v) => v,
-                    None => serde_json::json!({"type": "object", "properties": {}}),
-                }
-            } else {
-                serde_json::json!({"type": "object", "properties": {}})
-            }
+            // CB-P0.2 (full): if `input_schema` is omitted, fall back to the
+            // conventional path `schemas/{tool_name}.input.json` under the
+            // app directory. Discovery is silent — a missing conventional
+            // file just yields the open-object schema, so existing bundles
+            // are unaffected.
+            resolve_codecomponent_input_schema(name, config.input_schema.as_deref(), app_dir)
         } else if let Some(executor) = executor_opt {
             let namespaced = format!("{}:{}", dv_namespace, config.dataview);
             let method = config.method.as_deref().unwrap_or("GET");
@@ -1245,6 +1239,102 @@ mod tests {
         assert_eq!(entry["content"][0]["text"], serde_json::json!("Unknown tool: bad_tool"));
     }
 
+    // ── CB-P0.2 input_schema resolution ────────────────────────
+
+    /// Explicit `input_schema = "path"` is loaded from the app dir when
+    /// readable.
+    #[test]
+    fn resolve_input_schema_uses_explicit_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app_dir = tmp.path();
+        std::fs::create_dir_all(app_dir.join("custom")).unwrap();
+        std::fs::write(
+            app_dir.join("custom/explicit.json"),
+            r#"{"type":"object","properties":{"foo":{"type":"string"}}}"#,
+        ).unwrap();
+
+        let schema = resolve_codecomponent_input_schema(
+            "any_tool",
+            Some("custom/explicit.json"),
+            app_dir,
+        );
+        assert_eq!(schema["properties"]["foo"]["type"], "string");
+    }
+
+    /// CB-P0.2: when `input_schema` is omitted, the conventional path
+    /// `schemas/<tool_name>.input.json` is auto-discovered.
+    #[test]
+    fn resolve_input_schema_falls_back_to_conventional_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app_dir = tmp.path();
+        std::fs::create_dir_all(app_dir.join("schemas")).unwrap();
+        std::fs::write(
+            app_dir.join("schemas/pull_task.input.json"),
+            r#"{"type":"object","properties":{"taskId":{"type":"string"}},"required":["taskId"]}"#,
+        ).unwrap();
+
+        let schema = resolve_codecomponent_input_schema("pull_task", None, app_dir);
+        assert_eq!(schema["properties"]["taskId"]["type"], "string");
+        assert_eq!(schema["required"][0], "taskId");
+    }
+
+    /// CB-P0.2: explicit setting wins over the conventional file when both
+    /// exist — the bundle author's stated path is authoritative.
+    #[test]
+    fn resolve_input_schema_explicit_overrides_conventional() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app_dir = tmp.path();
+        std::fs::create_dir_all(app_dir.join("schemas")).unwrap();
+        std::fs::write(
+            app_dir.join("schemas/pull_task.input.json"),
+            r#"{"type":"object","properties":{"discovered":{"type":"boolean"}}}"#,
+        ).unwrap();
+        std::fs::create_dir_all(app_dir.join("custom")).unwrap();
+        std::fs::write(
+            app_dir.join("custom/explicit.json"),
+            r#"{"type":"object","properties":{"explicit":{"type":"integer"}}}"#,
+        ).unwrap();
+
+        let schema = resolve_codecomponent_input_schema(
+            "pull_task",
+            Some("custom/explicit.json"),
+            app_dir,
+        );
+        assert!(schema["properties"].get("explicit").is_some(),
+            "explicit declaration should win");
+        assert!(schema["properties"].get("discovered").is_none(),
+            "conventional file must be ignored when explicit is set");
+    }
+
+    /// Existing bundles (no explicit, no conventional file) keep getting
+    /// the open-object fallback. No regression.
+    #[test]
+    fn resolve_input_schema_falls_back_to_open_object_when_nothing_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let schema = resolve_codecomponent_input_schema("any_tool", None, tmp.path());
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+        assert_eq!(schema["properties"].as_object().unwrap().len(), 0);
+    }
+
+    /// Malformed conventional file → silent fallback to open object,
+    /// not a panic. Bundles can develop with WIP schemas without breaking
+    /// `tools/list`.
+    #[test]
+    fn resolve_input_schema_malformed_conventional_falls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app_dir = tmp.path();
+        std::fs::create_dir_all(app_dir.join("schemas")).unwrap();
+        std::fs::write(
+            app_dir.join("schemas/broken.input.json"),
+            "this isn't json {{",
+        ).unwrap();
+
+        let schema = resolve_codecomponent_input_schema("broken", None, app_dir);
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["properties"].as_object().unwrap().len(), 0);
+    }
+
     /// CB-P1.9: when the route template includes path variables, the matched
     /// values must reach the codecomponent handler under `path_params` —
     /// parity with the REST dispatch contract (`MatchedRoute.path_params`).
@@ -1282,6 +1372,50 @@ mod tests {
         assert_eq!(args["path_params"].as_object().map(|m| m.len()), Some(0));
         assert!(args["session"].is_null(), "session should be null when no auth");
     }
+}
+
+/// Resolve a codecomponent-backed MCP tool's `inputSchema` from disk.
+///
+/// CB-P0.2: lookup order is
+///
+/// 1. `config_path` — the explicit `input_schema = "..."` declaration.
+///    Used as-is when set, even if missing on disk (the bundle author asked
+///    for that file; we just fall through to open-schema if unreadable).
+/// 2. **Convention** — `<app_dir>/schemas/<tool_name>.input.json`. Picked
+///    up automatically when the explicit field is `None`. Lets bundles
+///    drop the per-tool `input_schema` line for the common case.
+/// 3. Open object schema fallback (`{"type":"object","properties":{}}`).
+///
+/// The conventional path matches what `riverpackage` and bundle authoring
+/// guides recommend. Pairs cleanly with external generators (e.g.
+/// `ts-json-schema-generator -p tsconfig.json -t MyToolInput -o
+/// schemas/my_tool.input.json`).
+fn resolve_codecomponent_input_schema(
+    tool_name: &str,
+    config_path: Option<&str>,
+    app_dir: &std::path::Path,
+) -> serde_json::Value {
+    let open_object = || serde_json::json!({"type": "object", "properties": {}});
+
+    // (1) explicit declaration
+    if let Some(path) = config_path {
+        let full_path = app_dir.join(path);
+        return std::fs::read_to_string(&full_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .unwrap_or_else(open_object);
+    }
+
+    // (2) conventional path: <app_dir>/schemas/<tool_name>.input.json
+    let conventional = app_dir.join("schemas").join(format!("{tool_name}.input.json"));
+    if let Ok(s) = std::fs::read_to_string(&conventional) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) {
+            return v;
+        }
+    }
+
+    // (3) fallback
+    open_object()
 }
 
 /// Project DataView parameters into MCP JSON Schema inputSchema.

--- a/docs/arch/rivers-mcp-view-spec.md
+++ b/docs/arch/rivers-mcp-view-spec.md
@@ -181,6 +181,53 @@ default = "active"                    →  "default": "active"
 
 The `location` field (path, query, body, header) is NOT exposed to the model. The model sees a flat input schema. The DataView engine handles routing each parameter to its declared location internally.
 
+#### 4.1.1 Codecomponent-backed tools — `inputSchema` resolution (CB-P0.2)
+
+Tools using `view = "..."` (codecomponent backend, §13.2) cannot be
+projected from DataView parameter declarations — the request shape
+lives in the handler's TypeScript types, not in declarative SQL. The
+framework resolves `inputSchema` for these tools in three steps:
+
+1. **Explicit declaration.** `[api.views.X.tools.Y].input_schema =
+   "schemas/foo.input.json"` — bundle author points at a JSON Schema
+   file relative to the app directory. The file is loaded at
+   `tools/list` time. Bundle-load validation (`MCP-VAL-8`) verifies the
+   path exists.
+
+2. **Conventional discovery.** When `input_schema` is omitted, the
+   framework looks for `<app_dir>/schemas/<tool_name>.input.json`
+   (named after the tool, not the handler). If present and valid JSON,
+   that file is used. This lets bundles drop the per-tool
+   `input_schema =` line for the common case — write the file at the
+   conventional path, the framework finds it.
+
+3. **Open-object fallback.** When neither path resolves, the framework
+   serves `{"type":"object","properties":{}}`. The model sees the tool
+   exists but gets no input shape — usable, but discoverability suffers.
+
+Recommended workflow for codecomponent tools with non-trivial input:
+
+- Define your handler's request type in TypeScript (e.g. `interface
+  PullTaskRequest { taskId: string; force?: boolean }`).
+- Generate the JSON Schema with the npm tool
+  [`ts-json-schema-generator`](https://github.com/vega/ts-json-schema-generator):
+
+  ```sh
+  npx ts-json-schema-generator \
+    --path 'libraries/handlers/lifecycle.ts' \
+    --type 'PullTaskRequest' \
+    --out 'schemas/pull_task.input.json'
+  ```
+
+- Commit the generated schema to the bundle. The conventional name
+  matches the tool name in `[api.views.X.tools.<tool_name>]` — discovery
+  is automatic, no `input_schema = "..."` line required in `app.toml`.
+
+This is the documented path until first-class TS-type → JSON Schema
+generation lands inside `riverpackage`. The convention works the same
+either way; the eventual CLI subcommand will write to the same file
+locations.
+
 ### 4.2 Tool Execution
 
 `tools/call` request:

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 2026-05-08 — CB-P0.2 (full): convention-based `input_schema` discovery
+
+Codecomponent-backed MCP tools that don't declare an explicit
+`input_schema = "..."` are now auto-discovered from the conventional
+path `<app_dir>/schemas/<tool_name>.input.json`. Removes the per-tool
+TOML duplication that was the original P0.2 pain point. Bundles can
+generate the JSON Schema with `npx ts-json-schema-generator` once per
+type and the framework picks it up — no `app.toml` change needed.
+
+| File | Change | Spec ref | Notes |
+|------|--------|----------|-------|
+| `crates/riversd/src/mcp/dispatch.rs` | New `resolve_codecomponent_input_schema` helper with three-tier lookup (explicit > conventional > open). 5 unit tests. | CB-P0.2 | Pure function; explicit declaration always wins; malformed conventional files fall through silently rather than 500ing the dispatcher. |
+| `docs/arch/rivers-mcp-view-spec.md` §4.1.1 | New section documenting resolution order + recommended `ts-json-schema-generator` workflow. | CB-P0.2 | |
+| `Cargo.toml` (workspace) | Patch bump. | CLAUDE.md versioning | |
+
+**Tests:** `cargo test -p riversd --lib` 485/485 (was 480; +5 covering
+all branches of the resolution logic). `cargo test -p rivers-runtime
+--lib` 246/246 (no change).
+
+**What this is and isn't:**
+
+- **Is:** Convention-based discovery + clear documentation of the
+  recommended workflow. Eliminates per-tool TOML duplication.
+- **Isn't:** A Rust-native TS-type → JSON Schema transformer. The
+  npm `ts-json-schema-generator` is the recommended path; a
+  Rust-native generator inside `riverpackage` is captured as a
+  follow-up but not needed to close the original ask.
+
+**Closes the original P0.2 batch.** All six items from the
+2026-05-08 CB MCP follow-up plan are now landed:
+
+| Item | PR |
+|---|---|
+| CB-P1.13 (capability propagation) | [#100](https://github.com/pcastone/rivers/pull/100) |
+| CB-P1.9 (path_params) | [#101](https://github.com/pcastone/rivers/pull/101) |
+| CB-P1.11 (response_headers) | [#102](https://github.com/pcastone/rivers/pull/102) |
+| CB-P1.10 (named guards) | [#103](https://github.com/pcastone/rivers/pull/103) |
+| CB-P1.12 (closed as duplicate) | [#104](https://github.com/pcastone/rivers/pull/104) |
+| CB-P0.2 (this PR) | follow-up minor bump at sprint end |
+
+---
+
 ## 2026-05-08 — CB-P1.12: closed as superseded by CB-P1.10 (docs only)
 
 `auth = "bearer"` will not ship as a first-class view mode. CB-P1.10


### PR DESCRIPTION
## Summary

- Codecomponent-backed MCP tools that don't declare an explicit `input_schema = "..."` are now auto-discovered from the conventional path `<app_dir>/schemas/<tool_name>.input.json`. Removes the per-tool TOML duplication that was the remaining half of P0.2 after P0.2.c shipped explicit schema files.
- Resolution order (new helper `resolve_codecomponent_input_schema`):
  1. Explicit `input_schema = "path"` — author's stated intent wins.
  2. `<app_dir>/schemas/<tool_name>.input.json` — convention auto-discovered when the explicit field is `None`.
  3. Open-object fallback `{"type":"object","properties":{}}` — existing bundles unchanged.
- Malformed conventional files fall through silently rather than 500ing the dispatcher.
- Spec section 4.1.1 documents the three-tier order and the recommended `npx ts-json-schema-generator` workflow.

**Why a convention rather than a Rust-native TS-type extractor:** the npm tool is ~10K LOC and well-maintained; bundling a less-mature port into `riverpackage` would balloon the crate without more value than this convention. The convention doesn't preclude a native generator later — it would write to the same file paths.

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followups.md` (Plan F).

**Closes the original 6-item CB MCP batch** (P0.2, P1.9, P1.10, P1.11, P1.12, P1.13).

## Test plan

- [x] `cargo test -p riversd --lib` — **485 passed** / 0 failed / 7 ignored (was 480; +5)
- [x] New tests cover all branches: explicit, conventional, explicit-overrides-conventional, missing both, malformed-conventional-falls-back
- [x] `cargo test -p rivers-runtime --lib` — 246/246 (no change)
- [x] Spec section 4.1.1 added with worked example
- [x] Version bumped to `0.60.7+1554080526`

🤖 Generated with [Claude Code](https://claude.com/claude-code)