### PR TITLE
fix(view): Plan G — WS + SSE datasource-wiring + slug parity (CB-P1.13 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.6+1545080526"
+version = "0.60.7+1554080526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.7+1554080526"
+version = "0.60.7+1618080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,90 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — Plan G: WS + SSE datasource-wiring + slug parity (CB-P1.13 follow-up)
+
+**Decision:** Closes the gutter item filed by Plan A (PR #100).
+WebSocket and SSE codecomponent handlers now go through the same
+`wire_datasources` + slug-to-`enrich` pattern that REST and MCP use,
+removing the silent-failure mode where `Rivers.db.execute('<ds>', ...)`
+in a WS or SSE handler would throw `CapabilityError` because the
+datasource map was never populated.
+
+The fix has two halves and bundles both into the same change (Standard 5
+— "fix while you're in there"):
+
+1. **Datasource wiring.** Each dispatch helper
+   (`websocket.rs::execute_ws_on_stream`,
+   `websocket.rs::dispatch_ws_lifecycle`,
+   `sse.rs::run_sse_push_loop`) now takes
+   `executor: Option<&DataViewExecutor>` and calls
+   `task_enrichment::wire_datasources` before
+   `task_enrichment::enrich`. Callers in
+   `server/streaming.rs::handle_ws_connection` snapshot the executor
+   from `ctx.dataview_executor.read().await` once per dispatched
+   hook/message and pass it through.
+
+2. **RT-CTX-APP-ID parity.** Each helper's `app_id` parameter became
+   `dv_namespace`. The slug — `matched.app_entry_point` — is what
+   `keystore_resolver.get_for_entry_point(...)` keys on and what JS
+   handlers see as `ctx.app_id`. Same correction REST and MCP got
+   in the canary sprint and Plan A (CB-P1.13).
+
+**Why snapshot the executor per dispatch rather than once per
+connection:** the executor lives behind an `RwLock<Option<...>>` to
+support hot-reload. Reading the lock per message preserves the
+hot-reload contract without holding the read guard across
+arbitrarily long connections. The cost is one read-lock acquire per
+WS message — negligible compared to the V8 dispatch cost itself.
+Same shape REST uses on every request.
+
+**Why MCP (PR #100) was fixed first and WS/SSE are this PR:** CB
+reported the symptom against MCP. The same gap existed in WS/SSE but
+wasn't reported because most WS/SSE handlers use `ctx.dataview(...)`
+rather than direct `Rivers.db.execute(...)`. Plan A explicitly
+narrowed scope to MCP and tracked the remainder in `todo/gutter.md`.
+This PR closes that gutter item.
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `crates/riversd/src/websocket.rs` | `execute_ws_on_stream` and `dispatch_ws_lifecycle` take `dv_namespace` + `executor`. Both call `wire_datasources` before `enrich`; both pass `dv_namespace` (slug) to `enrich`. Internal tests pass `None` for the executor (the engine-unavailable path is the unit's intent). | CB-P1.13 follow-up | Mirrors PR #100's pattern exactly. |
+| `crates/riversd/src/sse.rs` | `run_sse_push_loop` takes `dv_namespace` + `executor`. Same wiring + slug fix. | CB-P1.13 follow-up | `run_sse_push_loop` is `pub` but only test-callable today; updating it keeps the API consistent for the eventual production caller. |
+| `crates/riversd/src/server/streaming.rs` | `execute_ws_view` clones `matched.app_entry_point` instead of `matched.app_id`; `handle_ws_connection` reads `ctx.dataview_executor` per dispatched hook and threads it. Four dispatch call sites updated (`on_connect`, `on_message`, `on_stream`, `on_disconnect`). | CB-P1.13 follow-up | Single-point intercept on the snapshot — every helper that the WS connection runs sees the same per-tick view. |
+| `docs/arch/rivers-view-layer-spec.md` §6.9 + §7.5 | New sections documenting the datasource-capability-propagation contract for WS and SSE handlers (parity with §5/§13.2 of mcp spec). | CB-P1.13 follow-up | Closes the documentation gap. |
+| `todo/gutter.md` | WS/SSE entry removed. | CB-P1.13 follow-up | |
+
+**Spec reference:** `cb-rivers-feature-request.md` P1.13 (closed by
+PR #100); plan
+`docs/superpowers/plans/2026-05-08-cb-mcp-followup-batch-2.md` Plan G.
+
+**Test status:** `cargo test -p riversd --lib` 485/485 + 7 ignored
+(no regression vs. main). Pre-existing test
+`view_engine_tests::slow_observer_does_not_extend_request_latency`
+fails on `main` independently of this PR — verified by stashing all
+changes and reproducing the same failure on the bare `main` HEAD.
+Test passes the empty string for `dv_namespace` to `ViewContext::new`,
+which trips the dispatcher's empty-app_id check after the canary
+sprint's RT-CTX-APP-ID fix changed the source-of-truth for the value
+passed to `enrich`. Out of scope for Plan G; tracked separately for a
+follow-up that updates the test fixture.
+
+**Why no version bump:** sprint-end minor bump policy. The five
+capability items landing today (PR #100–#103, #105, this PR)
+collapse into the 0.61.0 minor that's held until you call sprint-end.
+Build stamp only.
+
+**Follow-up captured:** `polling/runner.rs::dispatch_change_detect`
+has an analogous `enrich(builder, app_id, ...)` call. The `app_id`
+there is already a slug (extracted via
+`task_enrichment::app_id_from_qualified_name`), so the slug-parity
+half is moot. Adding `wire_datasources` is a separate concern (the
+change-detect handler is a small diff callback not expected to need
+DB access). Tracked in gutter for a follow-up if/when reported.
+
+---
+
 ## 2026-05-08 — CB-P0.2 (full): convention-based `input_schema` discovery for codecomponent MCP tools
 
 **Decision:** Codecomponent-backed MCP tools that don't declare an

--- a/crates/riversd/src/server/streaming.rs
+++ b/crates/riversd/src/server/streaming.rs
@@ -275,7 +275,11 @@ pub(super) async fn execute_ws_view(
     let view_id = matched.view_id.clone();
     let trace_id = uuid::Uuid::new_v4().to_string();
     let config = matched.config.clone();
-    let app_id = matched.app_id.clone();
+    // Plan G: pass entry-point slug to the WS dispatch helpers (matches
+    // the RT-CTX-APP-ID parity fix REST + MCP got). `matched.app_id` is
+    // the manifest UUID — kept around if any audit/log line needs it,
+    // but not the value to thread into TaskContext.
+    let dv_namespace = matched.app_entry_point.clone();
 
     // Extract WebSocketUpgrade from the request parts (before body consumption)
     let (mut parts, _body) = request.into_parts();
@@ -297,7 +301,7 @@ pub(super) async fn execute_ws_view(
     let ctx_clone = ctx.clone();
     ws_upgrade
         .on_upgrade(move |socket| {
-            handle_ws_connection(ctx_clone, socket, view_id, config, ws_mode, trace_id, app_id)
+            handle_ws_connection(ctx_clone, socket, view_id, config, ws_mode, trace_id, dv_namespace)
         })
         .into_response()
 }
@@ -313,7 +317,7 @@ async fn handle_ws_connection(
     config: rivers_runtime::view::ApiViewConfig,
     ws_mode: crate::websocket::WebSocketMode,
     trace_id: String,
-    app_id: String,
+    dv_namespace: String,
 ) {
     use axum::extract::ws::Message;
     use crate::websocket::{
@@ -341,6 +345,10 @@ async fn handle_ws_connection(
     // Dispatch on_connect lifecycle hook
     if let Some(ref hooks) = config.ws_hooks {
         if let Some(ref on_connect) = hooks.on_connect {
+            // Plan G: snapshot executor before dispatching so codecomponent
+            // hooks see the per-app datasource set + correct slug.
+            let exec_guard = ctx.dataview_executor.read().await;
+            let executor = exec_guard.as_deref();
             match dispatch_ws_lifecycle(
                 &ctx.pool,
                 &on_connect.module,
@@ -349,7 +357,8 @@ async fn handle_ws_connection(
                 None,
                 None,
                 &trace_id,
-                &app_id,
+                &dv_namespace,
+                executor,
             )
             .await
             {
@@ -439,6 +448,8 @@ async fn handle_ws_connection(
                         if let Some(ref hook) = on_message_hook {
                             let message_val: serde_json::Value =
                                 serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text.to_string()));
+                            let exec_guard = ctx.dataview_executor.read().await;
+                            let executor = exec_guard.as_deref();
                             match dispatch_ws_lifecycle(
                                 &ctx.pool,
                                 &hook.module,
@@ -447,7 +458,8 @@ async fn handle_ws_connection(
                                 Some(&message_val),
                                 None,
                                 &trace_id,
-                                &app_id,
+                                &dv_namespace,
+                                executor,
                             ).await {
                                 Ok(reply) if !reply.is_null() => {
                                     let reply_str = serde_json::to_string(&reply).unwrap_or_default();
@@ -466,13 +478,16 @@ async fn handle_ws_connection(
                         if let Some(ref ep) = on_stream_ep {
                             let message_val: serde_json::Value =
                                 serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text.to_string()));
+                            let exec_guard = ctx.dataview_executor.read().await;
+                            let executor = exec_guard.as_deref();
                             match execute_ws_on_stream(
                                 &ctx.pool,
                                 ep,
                                 &message_val,
                                 &conn_id,
                                 &trace_id,
-                                &app_id,
+                                &dv_namespace,
+                                executor,
                             )
                             .await
                             {
@@ -532,6 +547,8 @@ async fn handle_ws_connection(
     // Dispatch on_disconnect lifecycle hook
     if let Some(ref hooks) = config.ws_hooks {
         if let Some(ref on_disconnect) = hooks.on_disconnect {
+            let exec_guard = ctx.dataview_executor.read().await;
+            let executor = exec_guard.as_deref();
             match dispatch_ws_lifecycle(
                 &ctx.pool,
                 &on_disconnect.module,
@@ -540,7 +557,8 @@ async fn handle_ws_connection(
                 None,
                 None,
                 &trace_id,
-                &app_id,
+                &dv_namespace,
+                executor,
             )
             .await
             {

--- a/crates/riversd/src/sse.rs
+++ b/crates/riversd/src/sse.rs
@@ -340,7 +340,8 @@ pub async fn run_sse_push_loop(
     mut event_rx: broadcast::Receiver<Event>,
     sender: mpsc::Sender<SseEvent>,
     trace_id: &str,
-    app_id: &str,
+    dv_namespace: &str,
+    executor: Option<&rivers_runtime::DataViewExecutor>,
 ) -> Result<(), StreamingError> {
     let tick_duration = if tick_interval_ms > 0 {
         Some(tokio::time::Duration::from_millis(tick_interval_ms))
@@ -421,9 +422,11 @@ pub async fn run_sse_push_loop(
             .entrypoint(entrypoint.clone())
             .args(args)
             .trace_id(trace_id.to_string());
+        // CB-P1.13 follow-up (Plan G): wire datasources + use slug for enrich.
+        let builder = crate::task_enrichment::wire_datasources(builder, executor, dv_namespace);
         let builder = crate::task_enrichment::enrich(
             builder,
-            app_id,
+            dv_namespace,
             rivers_runtime::process_pool::TaskKind::Rest,
         );
         let ctx = builder
@@ -654,6 +657,7 @@ mod tests {
             sender,
             "trace-1",
             "test-app",
+            None,
         )
         .await;
 
@@ -735,6 +739,7 @@ mod tests {
             sender,
             "trace-1",
             "test-app",
+            None,
         )
         .await;
 

--- a/crates/riversd/src/websocket.rs
+++ b/crates/riversd/src/websocket.rs
@@ -483,7 +483,8 @@ pub async fn execute_ws_on_stream(
     message: &serde_json::Value,
     connection_id: &ConnectionId,
     trace_id: &str,
-    app_id: &str,
+    dv_namespace: &str,
+    executor: Option<&rivers_runtime::DataViewExecutor>,
 ) -> Result<Option<serde_json::Value>, TaskError> {
     let args = serde_json::json!({
         "message": message,
@@ -494,9 +495,14 @@ pub async fn execute_ws_on_stream(
         .entrypoint(entrypoint.clone())
         .args(args)
         .trace_id(trace_id.to_string());
+    // CB-P1.13 follow-up (Plan G): wire per-app datasources before enrich,
+    // mirroring the REST + MCP paths so codecomponent handlers reached via
+    // WebSocket can call `Rivers.db.execute(...)`. RT-CTX-APP-ID parity:
+    // pass `dv_namespace` (entry-point slug) to enrich, not the manifest UUID.
+    let builder = crate::task_enrichment::wire_datasources(builder, executor, dv_namespace);
     let builder = crate::task_enrichment::enrich(
         builder,
-        app_id,
+        dv_namespace,
         rivers_runtime::process_pool::TaskKind::Rest,
     );
     let ctx = builder.build()?;
@@ -522,7 +528,8 @@ pub async fn dispatch_ws_lifecycle(
     message: Option<&serde_json::Value>,
     session: Option<&serde_json::Value>,
     trace_id: &str,
-    app_id: &str,
+    dv_namespace: &str,
+    executor: Option<&rivers_runtime::DataViewExecutor>,
 ) -> Result<serde_json::Value, TaskError> {
     let entrypoint = Entrypoint {
         module: hook_module.to_string(),
@@ -543,9 +550,11 @@ pub async fn dispatch_ws_lifecycle(
         .entrypoint(entrypoint)
         .args(args)
         .trace_id(trace_id.to_string());
+    // CB-P1.13 follow-up (Plan G): wire datasources + use slug for enrich.
+    let builder = crate::task_enrichment::wire_datasources(builder, executor, dv_namespace);
     let builder = crate::task_enrichment::enrich(
         builder,
-        app_id,
+        dv_namespace,
         rivers_runtime::process_pool::TaskKind::Rest,
     );
     let task_ctx = builder.build()?;
@@ -686,7 +695,7 @@ mod tests {
         let conn_id = ConnectionId("conn-1".to_string());
 
         let result =
-            execute_ws_on_stream(&pool, &entrypoint, &message, &conn_id, "trace-1", "test-app").await;
+            execute_ws_on_stream(&pool, &entrypoint, &message, &conn_id, "trace-1", "test-app", None).await;
         // Should fail with EngineUnavailable
         assert!(result.is_err());
     }
@@ -705,6 +714,7 @@ mod tests {
             Some(&serde_json::json!({"user_id": "u-1"})),
             "trace-ws-1",
             "test-app",
+            None,
         )
         .await;
         // Engine unavailable — expected in stub mode
@@ -724,6 +734,7 @@ mod tests {
             None,
             "trace-ws-2",
             "test-app",
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -741,6 +752,7 @@ mod tests {
             None,
             "trace-ws-3",
             "test-app",
+            None,
         )
         .await;
         assert!(result.is_err());

--- a/docs/arch/rivers-view-layer-spec.md
+++ b/docs/arch/rivers-view-layer-spec.md
@@ -454,6 +454,19 @@ Rivers re-validates the session against StorageEngine at the configured interval
 
 `session_revalidation_interval_s = 0` is the default — session is validated at connect time only.
 
+### 6.9 Datasource capability propagation (CB-P1.13)
+
+WebSocket codecomponent handlers (`on_stream`, `on_connect`,
+`on_message`, `on_disconnect`) receive the same per-app datasource set
+as REST and MCP handlers — calls to `Rivers.db.execute('<datasource>',
+...)` resolve against the app's datasource declarations identically.
+The dispatch path snapshots `ctx.dataview_executor` once per message
+and threads it through `task_enrichment::wire_datasources` before the
+handler runs.
+
+The handler also sees `ctx.app_id` as the entry-point slug (e.g.
+`cb-service`), not the manifest UUID. Same convention as REST and MCP.
+
 ---
 
 ## 7. Server-Sent Events Views
@@ -492,6 +505,17 @@ Same model as WebSocket (§6.8). Declare `session_revalidation_interval_s` to re
 view_type                       = "ServerSentEvents"
 session_revalidation_interval_s = 600   # re-check every 10 minutes
 ```
+
+### 7.5 Datasource capability propagation (CB-P1.13)
+
+SSE codecomponent handlers receive the same per-app datasource set as
+REST and MCP handlers — same convention as WebSocket §6.9. The
+push-loop dispatch path passes the executor + entry-point slug into
+`task_enrichment::wire_datasources` before each handler tick fires, so
+`Rivers.db.execute('<datasource>', ...)` resolves identically to a
+REST handler in the same app.
+
+`ctx.app_id` is the entry-point slug (matches REST/WS/MCP).
 
 ---
 

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 2026-05-08 — Plan G: WS + SSE datasource-wiring + slug parity
+
+Closes the gutter item filed by PR #100 (CB-P1.13). WebSocket and SSE
+codecomponent handlers now thread `wire_datasources` + the entry-point
+slug through to `task_enrichment::enrich` — same pattern REST and MCP
+adopted earlier. `Rivers.db.execute('<datasource>', ...)` from a WS or
+SSE handler will now resolve identically to a REST handler, and JS
+handlers see `ctx.app_id` as the slug (not the manifest UUID).
+
+| File | Change | Spec ref | Notes |
+|------|--------|----------|-------|
+| `crates/riversd/src/websocket.rs` | `execute_ws_on_stream`, `dispatch_ws_lifecycle` take `dv_namespace` + `Option<&DataViewExecutor>`. Wire-then-enrich in slug order. Internal tests updated. | CB-P1.13 follow-up | Mirrors PR #100. |
+| `crates/riversd/src/sse.rs` | `run_sse_push_loop` same shape. | CB-P1.13 follow-up | |
+| `crates/riversd/src/server/streaming.rs` | `execute_ws_view` clones `matched.app_entry_point` (slug) instead of `matched.app_id` (UUID). `handle_ws_connection` snapshots `ctx.dataview_executor` per dispatched hook and passes it through. Four call sites updated. | CB-P1.13 follow-up | Per-message read-lock acquire — same cost shape REST has per request. |
+| `docs/arch/rivers-view-layer-spec.md` §6.9 + §7.5 | New sections documenting the contract. | CB-P1.13 follow-up | |
+| `todo/gutter.md` | WS/SSE entry removed. | | |
+| `Cargo.toml` (workspace) | Build-stamp-only bump (sprint-end policy). | CLAUDE.md versioning | |
+
+**Tests:** 485/485 riversd lib (no regression).
+
+**Pre-existing test failure noted:**
+`view_engine_tests::slow_observer_does_not_extend_request_latency`
+fails on bare `main` independently of this PR — confirmed by stashing
+this work and reproducing the failure. Root cause is a test fixture
+that passes empty `dv_namespace` to `ViewContext::new`, tripping the
+dispatcher's empty-app_id check after the canary sprint's
+RT-CTX-APP-ID fix. Out of scope here; tracked for a separate fix.
+
+**Follow-up:** `polling/runner.rs::dispatch_change_detect` has the
+same enrich call shape but already passes a slug-equivalent value
+(via `task_enrichment::app_id_from_qualified_name`). Adding
+`wire_datasources` there is a separate concern — the change-detect
+handler is a small diff callback that doesn't typically need DB
+access. Tracked in gutter for if/when reported.
+
+---
+
 ## 2026-05-08 — CB-P0.2 (full): convention-based `input_schema` discovery
 
 Codecomponent-backed MCP tools that don't declare an explicit

--- a/todo/gutter.md
+++ b/todo/gutter.md
@@ -1,18 +1,25 @@
 # Moved to tasks.md — 2026-04-30
 
-## 2026-05-08 — Datasource wiring: WebSocket + SSE dispatch parity
+## 2026-05-08 — Polling change-detect callback datasource wiring
 
-CB-P1.13 fixed `wire_datasources` for the MCP `view=` dispatch path. The
-same gap exists in two more sites:
+Plan G (PR pending) closed the WS/SSE datasource-wiring gap.
+`crates/riversd/src/polling/runner.rs::dispatch_change_detect` has an
+analogous `enrich(builder, app_id, ...)` call but already passes a
+slug-equivalent value (extracted via
+`task_enrichment::app_id_from_qualified_name`). The remaining concern
+is wiring per-app datasources via `task_enrichment::wire_datasources`
+so the change-detect callback could call `Rivers.db.execute(...)` if a
+bundle author's diff logic needs DB access. Currently a low-priority
+follow-up — the change-detect handler is a small diff callback not
+expected to need DB. Track for if/when reported.
 
-- `crates/riversd/src/websocket.rs:497` and `:546`
-- `crates/riversd/src/sse.rs:424`
+## 2026-05-08 — Pre-existing test failure on `main`
 
-Both call `task_enrichment::enrich` only — they don't call
-`task_enrichment::wire_datasources`, so `Rivers.db.execute('<ds>', ...)`
-in a WS or SSE handler will throw `CapabilityError`. Symptoms haven't
-been reported, likely because most WS/SSE handlers lean on
-`ctx.dataview(...)` rather than direct DB calls. Fix is mechanical: drop
-in the `wire_datasources` call before `enrich` at each site, mirror REST
-ordering. Track separately so the P1.13 PR stays narrow and CB can pin
-to a specific version when their MCP `view=` flows go green.
+`crates/riversd/tests/view_engine_tests.rs::slow_observer_does_not_extend_request_latency`
+fails on bare `main` (verified by stashing Plan G work and
+reproducing). Root cause: the test passes empty `dv_namespace` to
+`ViewContext::new`, which trips the dispatcher's empty-app_id check
+after the canary sprint's RT-CTX-APP-ID fix changed the
+source-of-truth for what gets passed to `enrich`. Fix is to update
+the test fixture to pass a non-empty `dv_namespace`. Small,
+self-contained.


### PR DESCRIPTION
## Summary

- Closes the gutter item filed by [#100](https://github.com/pcastone/rivers/pull/100) (CB-P1.13). WebSocket and SSE codecomponent handlers now thread `wire_datasources` + the entry-point slug through to `task_enrichment::enrich` — same pattern REST and MCP adopted earlier.
- **Datasource wiring:** `execute_ws_on_stream`, `dispatch_ws_lifecycle`, `run_sse_push_loop` take `Option<&DataViewExecutor>` and call `task_enrichment::wire_datasources` before `enrich`. The WS caller in `handle_ws_connection` snapshots `ctx.dataview_executor` per dispatched hook.
- **RT-CTX-APP-ID parity:** each helper's `app_id` parameter became `dv_namespace` (slug). Same correction REST and MCP got in the canary sprint and [#100](https://github.com/pcastone/rivers/pull/100).
- `Rivers.db.execute('<datasource>', ...)` from WS or SSE handlers now resolves identically to REST.
- Spec sections 6.9 (WebSocket) and 7.5 (SSE) document the contract.

**Sprint-end policy:** no patch bump. Build-stamp-only on top of 0.60.7. The minor will collapse all sprint capabilities into 0.61.0 when you call sprint-end.

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followup-batch-2.md` (Plan G).

## Test plan

- [x] `cargo test -p riversd --lib` — **485 passed** / 0 failed / 7 ignored (no regression vs main)
- [x] WS dispatch tests pass with new signature (None executor, None datasources — engine-unavailable path unchanged)
- [x] Spec parity sections added
- [x] Gutter updated — WS/SSE entry replaced with two smaller follow-ups (polling change-detect, pre-existing test fixture)

**Pre-existing test note:** `view_engine_tests::slow_observer_does_not_extend_request_latency` fails on bare `main` independently of this PR. Verified by stashing all Plan G changes and reproducing on the unmodified main HEAD. Tracked separately in `todo/gutter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)