### PR TITLE
fix(test): gutter cleanup — slow_observer fixture + scope decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.7+1618080526"
+version = "0.60.7+1733080526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/riversd/tests/view_engine_tests.rs
+++ b/crates/riversd/tests/view_engine_tests.rs
@@ -594,11 +594,17 @@ async fn slow_observer_does_not_extend_request_latency() {
     });
 
     let req = ParsedRequest::new("GET", "/api/slow");
+    // Pre-existing main failure fix: ViewContext::new(req, trace_id,
+    // app_id, dv_namespace, ...) — `dv_namespace` is what the
+    // canary-sprint RT-CTX-APP-ID fix passes to `enrich`. An empty
+    // dv_namespace trips the dispatcher's empty-app_id check at the
+    // post-canary-fix code path. Use the same slug as app_id so the
+    // observer dispatch reaches the pool.
     let mut ctx = ViewContext::new(
         req,
         "trace-g-r4".into(),
         "test-app".into(),
-        String::new(),
+        "test-app".into(),
         String::new(),
         String::new(),
     );

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2026-05-08 — Gutter cleanup: pre-existing test fixture fix + scope decisions
+
+Closes the `slow_observer_does_not_extend_request_latency` failure
+that pre-existed on `main`. The test was passing empty `dv_namespace`
+to `ViewContext::new`, which trips the dispatcher's empty-app_id check
+after the canary-sprint RT-CTX-APP-ID fix. Fixture now passes the
+`"test-app"` slug consistently (matches the `app_id` argument).
+
+Two other gutter items deferred with documented decisions in
+`todo/gutter.md`:
+
+- **Polling change-detect datasource wiring** — closed as
+  deprioritized. Threading a `DataViewExecutor` through three function
+  signatures for a callback that's a fast diff function isn't
+  justified by speculation; the slug-equivalent fix already in
+  `polling/runner.rs:89` handles keystore.
+- **Plan H follow-ups** (lift chain prohibition, per-view-type
+  runtime tests) — both deferred. Chain prohibition lift requires
+  runtime semantics work that has no reported demand. Per-view-type
+  tests need a unified HTTP harness that's its own initiative.
+
+| File | Change | Notes |
+|------|--------|-------|
+| `crates/riversd/tests/view_engine_tests.rs` | One-line fixture fix: pass `"test-app"` as `dv_namespace` instead of empty string. Comment explains the canary-fix interaction. | |
+| `todo/gutter.md` | Rewritten with honest scope decisions. | |
+| `Cargo.toml` (workspace) | Build-stamp-only bump (sprint-end policy). | |
+
+**Tests:** `slow_observer_does_not_extend_request_latency` passes;
+no regressions across riversd test binaries.
+
+---
+
 ## 2026-05-08 — Plan H: `guard_view` honoured uniformly across all view types
 
 Closes the long-standing footgun where `guard_view` was a first-class

--- a/todo/gutter.md
+++ b/todo/gutter.md
@@ -1,25 +1,69 @@
 # Moved to tasks.md — 2026-04-30
 
-## 2026-05-08 — Polling change-detect callback datasource wiring
+## 2026-05-08 — Gutter cleanup decisions
 
-Plan G (PR pending) closed the WS/SSE datasource-wiring gap.
-`crates/riversd/src/polling/runner.rs::dispatch_change_detect` has an
-analogous `enrich(builder, app_id, ...)` call but already passes a
-slug-equivalent value (extracted via
-`task_enrichment::app_id_from_qualified_name`). The remaining concern
-is wiring per-app datasources via `task_enrichment::wire_datasources`
-so the change-detect callback could call `Rivers.db.execute(...)` if a
-bundle author's diff logic needs DB access. Currently a low-priority
-follow-up — the change-detect handler is a small diff callback not
-expected to need DB. Track for if/when reported.
-
-## 2026-05-08 — Pre-existing test failure on `main`
+### Closed: pre-existing test fixture failure (PR pending)
 
 `crates/riversd/tests/view_engine_tests.rs::slow_observer_does_not_extend_request_latency`
-fails on bare `main` (verified by stashing Plan G work and
-reproducing). Root cause: the test passes empty `dv_namespace` to
+was failing on `main` because the test passed empty `dv_namespace` to
 `ViewContext::new`, which trips the dispatcher's empty-app_id check
-after the canary sprint's RT-CTX-APP-ID fix changed the
-source-of-truth for what gets passed to `enrich`. Fix is to update
-the test fixture to pass a non-empty `dv_namespace`. Small,
-self-contained.
+after the canary-sprint RT-CTX-APP-ID fix. Resolution: pass
+`"test-app"` (matching the existing app_id arg) for the dv_namespace.
+One-line fixture change.
+
+### Closed-as-deprioritized: polling change-detect datasource wiring
+
+Initial gutter note suggested adding `wire_datasources` to
+`crates/riversd/src/polling/runner.rs::dispatch_change_detect` for
+parity with REST/MCP/WS/SSE. On closer look, threading a real
+`DataViewExecutor` through the polling path requires changing three
+function signatures (`drive_sse_push_loop` →
+`execute_poll_tick_inmemory` → `dispatch_change_detect`) for a
+callback whose contract is "fast diff function comparing prev to
+current" — `Rivers.db.execute(...)` from a change-detect handler is
+unusual. The slug-equivalent fix is already in place (line 89,
+`app_id_from_qualified_name`), so keystore lookups work. Deferring
+the datasource-wiring extension until a real bundle author asks for
+it; the surface change isn't justified by speculation.
+
+## 2026-05-08 — Plan H follow-ups (deliberately deferred)
+
+### Lift v1 chain prohibition
+
+Plan H rejected `guard_view` chains (target view declaring its own
+`guard_view`) at validate time with a single rule that catches
+self-reference, mutual recursion, and arbitrary depth. Multi-tenant
+deployments may eventually want chains (e.g. `tenant_auth →
+tenant_role_check`), but Plan H's multi-tenant motivation was
+per-route guards, not chained guards.
+
+**Why deferred:** lifting the prohibition is non-trivial. It requires
+(1) replacing the validator's chain-rejection rule with cycle
+detection (DFS, depth cap), (2) extending the runtime helper to
+dispatch chains transitively, (3) defining how `session_claims` from
+multiple guard levels merge, (4) spec section overhaul, (5)
+cross-level tests. ~2-3 hours of focused work that adds runtime
+complexity to solve a use case nobody has reported. Re-open when a
+real bundle authoring scenario surfaces.
+
+### Per-view-type runtime tests for `guard_view`
+
+Plan H ships with config-side validator tests (X014, W009, W010, plus
+the original guard-passing-path tests) but no end-to-end runtime
+tests that hit a real REST/WS/SSE/streaming-REST view, fire a guard
+codecomponent, and observe `{ allow: true/false }` causing
+proceed/401. The MCP path is exercised by the existing canary, but
+non-MCP transports lack an integrated test harness.
+
+**Why deferred:** the test harness work is broader than the test
+itself. Each transport (REST, WS, SSE) needs a way to:
+1. Spin up a riversd instance with a bundle declaring two views
+   (guard + protected).
+2. Issue requests with bearer tokens / cookies.
+3. Inspect responses for HTTP 401 vs handler output.
+
+The closest existing infrastructure is the canary suite, which is
+production-shape (bundle on disk, `riversd` running) — heavier than
+unit tests want. A focused harness would be valuable but is its own
+PR or initiative. Re-open if a guard regression surfaces in
+production.


### PR DESCRIPTION
## Summary

- Closes the `slow_observer_does_not_extend_request_latency` test failure that pre-existed on `main`. Fixture was passing empty `dv_namespace` to `ViewContext::new`, which trips the dispatcher's empty-app_id check after the canary-sprint RT-CTX-APP-ID fix made `enrich` consume `dv_namespace` instead of `app_id`. Fixture now passes the `"test-app"` slug consistently.
- Two adjacent gutter items closed with honest scope decisions documented in `todo/gutter.md`:
  1. **Polling change-detect datasource wiring** — closed as deprioritized. Threading a `DataViewExecutor` through three function signatures for a fast-diff callback isn't justified without reported demand.
  2. **Plan H follow-ups** (lift v1 chain prohibition; per-view-type runtime tests) — both deferred with rationale. Chain lift needs non-trivial runtime semantics work for an unreported use case; per-view-type tests need a unified HTTP harness that's its own initiative.

## Test plan

- [x] `cargo test -p riversd --test view_engine_tests slow_observer_does_not_extend_request_latency` — now passes
- [x] `cargo test -p riversd --tests` — no regressions across all test binaries
- [x] Build-stamp-only bump per sprint-end policy: `0.60.7+1733080526 → 0.60.7+1909080526`

🤖 Generated with [Claude Code](https://claude.com/claude-code)