### PR TITLE
feat(view): lift v1 chain prohibition for guard_view (CB-P1.10 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.7+1733080526"
+version = "0.60.7+1909080526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.7+1909080526"
+version = "0.60.7+2027080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,95 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — Lift v1 chain prohibition: guard_view chains supported up to depth 5
+
+**Decision:** Plan H shipped a v1 chain prohibition (any `guard_view`
+target itself declaring `guard_view` was rejected at validate time).
+This entry lifts that restriction — chains are now allowed up to
+`MAX_GUARD_CHAIN_DEPTH` (5 hops past the protected view), with
+cycle detection replacing the blanket prohibition.
+
+**Why ship now:** Plan H's multi-tenant motivation extends naturally
+to chained auth (`tenant_auth → tenant_role_check → ...`). Composing
+guards is strictly more powerful than collapsing both checks into
+one beefier handler — chains let bundle authors build reusable
+guard primitives. The runtime work landed in this PR is bounded
+(walk chain → dispatch in order → short-circuit on first deny).
+
+**Validator change.** The single "target must not declare
+guard_view" rule is replaced with a chain walker that:
+
+- Tracks visited views in a HashSet (catches self-reference,
+  mutual recursion, longer cycles)
+- Caps chain length at 5 hops past the protected view
+- Re-applies per-hop X014 checks (target exists, target is
+  codecomponent)
+- Re-applies per-hop W009 (auth = "session" warns at any depth)
+- W010 still fires once at the chain head
+
+**Runtime change.** `run_named_guard_preflight` is restructured into
+two pieces:
+
+- `build_guard_chain` — walks from the initial guard view, returns
+  outermost-first chain (defensive runtime cycle/depth checks
+  return 500, since the validator should have caught these at
+  config load).
+- `dispatch_one_guard` — single-level dispatch (the previous
+  helper's body, refactored to take borrows so it can be called
+  in a loop).
+- Public `run_named_guard_preflight` calls `build_guard_chain`,
+  reverses to deepest-first, then dispatches each in order via
+  `dispatch_one_guard`. First `allow: false` short-circuits with
+  HTTP 401.
+
+**Why dispatch deepest-leaf-first:** semantically the deepest leaf
+is the "lowest" gate (e.g. token validation); each layer above it
+adds further gates (e.g. role check). Running deepest first matches
+the intuition that base auth precedes role-specific checks.
+
+**Why depth cap of 5:** realistic max useful depth is 3
+(auth → role → resource). Cap at 5 leaves headroom without
+inviting pathological chains.
+
+**Why claims-propagation deferred:** propagating session_claims
+across chain levels (so the role-check guard sees the token-validate
+guard's claims) opens semantic decisions about merge order, key
+collisions, and `ctx.session` visibility for the protected view.
+Each is a real product decision; v1 ships the simpler "allow/deny
+composition only" contract. Bundles that need cross-level data flow
+can use `ctx.store` or pass via headers in v1.
+
+**Files affected:**
+
+| File | Change | Spec ref | Method |
+|------|--------|----------|--------|
+| `crates/rivers-runtime/src/validate_crossref.rs` | Replaced chain prohibition with cycle detection + depth cap. Per-hop codecomponent + W009 checks. | CB-P1.10 follow-up | DFS visited tracking; cap at 5. |
+| `crates/riversd/src/security_pipeline.rs` | Refactored helper into `build_guard_chain` + `dispatch_one_guard`; public `run_named_guard_preflight` walks chain inside-out. | CB-P1.10 follow-up | Defensive runtime cycle/depth re-checks return 500 (validator should have caught at config load). |
+| `crates/rivers-runtime/src/validate_crossref.rs` (tests) | 4 new tests + flipped expectations on the previously-rejecting chain test. | CB-P1.10 follow-up | Coverage: chain-of-3 passes, chain-at-depth-5 passes, chain-of-6 fails (depth cap), per-hop codecomponent check enforced, W009 fires on chain hops. |
+| `docs/arch/rivers-view-layer-spec.md` §14.4 | New "Chain composition" section with multi-tenant example and depth/cycle/claims rules. §14.5 constraint table updated. | CB-P1.10 follow-up | |
+| `docs/arch/rivers-mcp-view-spec.md` §13.5 | Constraint table updated to match the lifted shape. | CB-P1.10 follow-up | |
+| `todo/gutter.md` | Closed the "Lift v1 chain prohibition" deferred item. | CB-P1.10 follow-up | |
+
+**Spec reference:** Plan H rebuilt
+(`docs/superpowers/plans/2026-05-08-cb-mcp-followup-batch-2-h-rebuilt.md`)
+explicitly named chain lift as a follow-up trigger; this entry is
+that follow-up.
+
+**Resolution method:** Re-read the v1 prohibition rule. Confirmed
+the validator rule was a single early-return; replaced with chain
+walker. Confirmed the runtime helper had a single dispatch site;
+factored into chain-walk + per-level dispatch. Picked depth cap 5
+based on realistic-max-useful-depth (3) plus headroom (2). Picked
+deepest-first dispatch order to match auth-then-role intuition.
+
+**Test status:** `cargo test -p rivers-runtime --lib` 256/256 (was
+252; +4 new chain tests, -1 renamed). `cargo test -p riversd --lib`
+485/485 (no regression).
+
+**Why no version bump:** sprint-end policy. Build stamp only.
+
+---
+
 ## 2026-05-08 — Plan H: `guard_view` honoured uniformly across all view types (CB-P1.10 follow-up)
 
 **Decision:** Closes the long-standing footgun where `guard_view`

--- a/crates/rivers-runtime/src/validate_crossref.rs
+++ b/crates/rivers-runtime/src/validate_crossref.rs
@@ -684,134 +684,179 @@ fn check_view_refs(
             }
         }
 
-        // X014: `guard_view = "name"` must reference a view in the same app
-        // that has a codecomponent handler — DataView- and None-handler views
-        // can't return the `{ allow: bool }` envelope the named-guard contract
-        // expects. CB-P1.10.
-        if let Some(ref guard_view_name) = view.guard_view {
-            match app.config.api.views.get(guard_view_name.as_str()) {
-                Some(target) => {
-                    if !matches!(target.handler, HandlerConfig::Codecomponent { .. }) {
-                        let kind = match &target.handler {
-                            HandlerConfig::Dataview { .. } => "dataview",
-                            HandlerConfig::Codecomponent { .. } => "codecomponent",
-                            HandlerConfig::None {} => "none",
-                        };
-                        results.push(
-                            ValidationResult::fail(
-                                error_codes::X014,
-                                format!("{}/app.toml", app_name),
-                                format!(
-                                    "View '{}' guard_view '{}' must reference a codecomponent-handler view; got '{}'",
-                                    view_name, guard_view_name, kind,
-                                ),
-                            )
-                            .with_app(app_name)
-                            .with_table_path(format!("api.views.{}", view_name))
-                            .with_field("guard_view"),
-                        );
-                    } else if target.guard_view.is_some() {
-                        // CB-P1.10 Plan H.4: chains are not supported in v1.
-                        // Catches self-reference (V → V), mutual recursion
-                        // (A → B → A), and arbitrarily deep chains in one
-                        // check. Lift this restriction in a follow-up if a
-                        // real multi-tenant chained-auth use case surfaces;
-                        // cycle detection then becomes the constraint.
-                        results.push(
-                            ValidationResult::fail(
-                                error_codes::X014,
-                                format!("{}/app.toml", app_name),
-                                format!(
-                                    "View '{}' guard_view '{}' must not itself declare a guard_view (chains are not supported in v1; the named-guard preflight runs once per request, not transitively).",
-                                    view_name, guard_view_name,
-                                ),
-                            )
-                            .with_app(app_name)
-                            .with_table_path(format!("api.views.{}", view_name))
-                            .with_field("guard_view"),
-                        );
-                    } else {
-                        // CB-P1.10 Plan H.5: warn when the guard target has
-                        // `auth = "session"`. Sessions don't exist when the
-                        // guard runs (the guard IS the auth boundary), so
-                        // the session pipeline would never let the guard
-                        // run for an unauthenticated request — defeats the
-                        // purpose. Warning, not error: chained-auth setups
-                        // could be intentional.
-                        if target.auth.as_deref() == Some("session") {
-                            let mut w = ValidationResult::warn(
-                                error_codes::W009,
-                                format!(
-                                    "View '{}' guard_view '{}' has auth = \"session\" — the named-guard preflight runs before any session validation, so a request without a valid session would never reach this guard. Consider auth = \"none\" on the guard view itself.",
-                                    view_name, guard_view_name,
-                                ),
-                            )
-                            .with_app(app_name)
-                            .with_table_path(format!("api.views.{}", guard_view_name))
-                            .with_field("auth");
-                            w.file = Some(format!("{}/app.toml", app_name));
-                            results.push(w);
-                        }
+        // X014: `guard_view = "name"` cross-reference + chain validation.
+        //
+        // Walks the chain starting at the protected view's `guard_view`
+        // and verifies every hop:
+        //   - target view exists in the same app
+        //   - target view's handler is a codecomponent (DataView and
+        //     `none` handlers can't return the `{ allow }` envelope)
+        //   - chain length stays within `MAX_GUARD_CHAIN_DEPTH`
+        //   - chain does not cycle (visited set; catches self-reference,
+        //     mutual recursion, and longer cycles)
+        //
+        // W009: any hop with `auth = "session"` warns — sessions don't
+        // exist when the guard runs.
+        // W010: protected view declares both `guard = true` and
+        // `guard_view = "..."` — applies once at the chain head.
+        //
+        // CB-P1.10 Plan H.4 (initial v1 chain prohibition) +
+        // post-Plan-H lift to support per-tenant guard composition.
+        if let Some(ref initial_guard_name) = view.guard_view {
+            // W010 — applies to the protected view itself, not chain links.
+            if view.guard {
+                let mut w = ValidationResult::warn(
+                    error_codes::W010,
+                    format!(
+                        "View '{}' has both `guard = true` (server-wide auth gate) and `guard_view = \"{}\"` (per-view gate). Two auth gates on one view is unusual; verify this is intentional.",
+                        view_name, initial_guard_name,
+                    ),
+                )
+                .with_app(app_name)
+                .with_table_path(format!("api.views.{}", view_name));
+                w.file = Some(format!("{}/app.toml", app_name));
+                results.push(w);
+            }
 
-                        // CB-P1.10 Plan H.5: warn when the protected view
-                        // declares both `guard = true` (server-wide gate)
-                        // and `guard_view = "..."` (per-view gate). Two
-                        // auth gates on the same view is unusual and most
-                        // likely a configuration mistake. Warning, not
-                        // error: leaves room for legitimate edge cases.
-                        if view.guard {
-                            let mut w = ValidationResult::warn(
-                                error_codes::W010,
-                                format!(
-                                    "View '{}' has both `guard = true` (server-wide auth gate) and `guard_view = \"{}\"` (per-view gate). Two auth gates on one view is unusual; verify this is intentional.",
-                                    view_name, guard_view_name,
-                                ),
-                            )
-                            .with_app(app_name)
-                            .with_table_path(format!("api.views.{}", view_name));
-                            w.file = Some(format!("{}/app.toml", app_name));
-                            results.push(w);
-                        }
+            const MAX_GUARD_CHAIN_DEPTH: usize = 5;
+            let mut visited: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            visited.insert(view_name.to_string());
 
-                        results.push(
-                            ValidationResult::pass(
-                                format!("{}/app.toml", app_name),
-                                format!(
-                                    "View '{}' guard_view '{}' resolved",
-                                    view_name, guard_view_name,
-                                ),
-                            )
-                            .with_app(app_name)
-                            .with_crossref(
-                                format!("api.views.{}.guard_view", view_name),
-                                guard_view_name.as_str(),
-                                "view",
+            let mut current = initial_guard_name.clone();
+            let mut chain_failed = false;
+
+            loop {
+                // Cycle check (against the protected view + every hop seen).
+                if !visited.insert(current.clone()) {
+                    results.push(
+                        ValidationResult::fail(
+                            error_codes::X014,
+                            format!("{}/app.toml", app_name),
+                            format!(
+                                "View '{}' guard_view chain forms a cycle revisiting '{}' — guards cannot reference themselves directly or transitively.",
+                                view_name, current,
                             ),
-                        );
-                    }
+                        )
+                        .with_app(app_name)
+                        .with_table_path(format!("api.views.{}", view_name))
+                        .with_field("guard_view"),
+                    );
+                    chain_failed = true;
+                    break;
                 }
-                None => {
-                    let mut result = ValidationResult::fail(
-                        error_codes::X014,
-                        format!("{}/app.toml", app_name),
+
+                // Depth cap (counts hops; 5 hops past the protected view).
+                if visited.len() > MAX_GUARD_CHAIN_DEPTH + 1 {
+                    results.push(
+                        ValidationResult::fail(
+                            error_codes::X014,
+                            format!("{}/app.toml", app_name),
+                            format!(
+                                "View '{}' guard_view chain exceeds MAX_GUARD_CHAIN_DEPTH ({MAX_GUARD_CHAIN_DEPTH}) — collapse intermediate guards into a single handler.",
+                                view_name,
+                            ),
+                        )
+                        .with_app(app_name)
+                        .with_table_path(format!("api.views.{}", view_name))
+                        .with_field("guard_view"),
+                    );
+                    chain_failed = true;
+                    break;
+                }
+
+                // Existence check.
+                let target = match app.config.api.views.get(current.as_str()) {
+                    Some(t) => t,
+                    None => {
+                        let mut result = ValidationResult::fail(
+                            error_codes::X014,
+                            format!("{}/app.toml", app_name),
+                            format!(
+                                "View '{}' references guard_view '{}' not declared in {}/app.toml",
+                                view_name, current, app_name,
+                            ),
+                        )
+                        .with_app(app_name)
+                        .with_table_path(format!("api.views.{}", view_name))
+                        .with_field("guard_view");
+                        let known: Vec<&str> = app.config.api.views.keys()
+                            .map(|s| s.as_str())
+                            .collect();
+                        if let Some(sug) = crate::validate_format::suggest_key(
+                            current.as_str(), &known,
+                        ) {
+                            result = result.with_suggestion(sug);
+                        }
+                        results.push(result);
+                        chain_failed = true;
+                        break;
+                    }
+                };
+
+                // Codecomponent check.
+                if !matches!(target.handler, HandlerConfig::Codecomponent { .. }) {
+                    let kind = match &target.handler {
+                        HandlerConfig::Dataview { .. } => "dataview",
+                        HandlerConfig::Codecomponent { .. } => "codecomponent",
+                        HandlerConfig::None {} => "none",
+                    };
+                    results.push(
+                        ValidationResult::fail(
+                            error_codes::X014,
+                            format!("{}/app.toml", app_name),
+                            format!(
+                                "View '{}' guard_view chain reaches '{}' which must be a codecomponent-handler view; got '{}'",
+                                view_name, current, kind,
+                            ),
+                        )
+                        .with_app(app_name)
+                        .with_table_path(format!("api.views.{}", view_name))
+                        .with_field("guard_view"),
+                    );
+                    chain_failed = true;
+                    break;
+                }
+
+                // W009 — warn per hop where target.auth = "session".
+                if target.auth.as_deref() == Some("session") {
+                    let mut w = ValidationResult::warn(
+                        error_codes::W009,
                         format!(
-                            "View '{}' references guard_view '{}' not declared in {}/app.toml",
-                            view_name, guard_view_name, app_name,
+                            "View '{}' guard chain hop '{}' has auth = \"session\" — the named-guard preflight runs before any session validation, so a request without a valid session would never reach this guard. Consider auth = \"none\" on the guard view itself.",
+                            view_name, current,
                         ),
                     )
                     .with_app(app_name)
-                    .with_table_path(format!("api.views.{}", view_name))
-                    .with_field("guard_view");
-                    let known: Vec<&str> = app.config.api.views.keys()
-                        .map(|s| s.as_str())
-                        .collect();
-                    if let Some(sug) = crate::validate_format::suggest_key(
-                        guard_view_name.as_str(), &known,
-                    ) {
-                        result = result.with_suggestion(sug);
-                    }
-                    results.push(result);
+                    .with_table_path(format!("api.views.{}", current))
+                    .with_field("auth");
+                    w.file = Some(format!("{}/app.toml", app_name));
+                    results.push(w);
                 }
+
+                // Walk to next hop (if any).
+                match &target.guard_view {
+                    Some(next) => current = next.clone(),
+                    None => break,
+                }
+            }
+
+            if !chain_failed {
+                results.push(
+                    ValidationResult::pass(
+                        format!("{}/app.toml", app_name),
+                        format!(
+                            "View '{}' guard_view chain (head '{}') resolved",
+                            view_name, initial_guard_name,
+                        ),
+                    )
+                    .with_app(app_name)
+                    .with_crossref(
+                        format!("api.views.{}.guard_view", view_name),
+                        initial_guard_name.as_str(),
+                        "view",
+                    ),
+                );
             }
         }
 
@@ -2088,8 +2133,7 @@ mod tests {
 
     #[test]
     fn x014_guard_view_self_reference_fails() {
-        // V.guard_view = V (V references itself). Caught by the chain
-        // check: V's target is V, V has guard_view set.
+        // V.guard_view = V — caught by cycle detection.
         let mut views = HashMap::new();
         let mut self_ref = make_view_codecomponent(vec![]);
         self_ref.guard_view = Some("self_ref".into());
@@ -2111,8 +2155,8 @@ mod tests {
             "expected X014 for guard_view self-reference");
         assert!(results.iter().any(|r|
             r.error_code.as_deref() == Some("X014")
-                && r.message.contains("must not itself declare a guard_view")
-        ), "expected chain-rejection error message");
+                && r.message.contains("forms a cycle")
+        ), "expected cycle-detection error message");
     }
 
     #[test]
@@ -2144,13 +2188,13 @@ mod tests {
     }
 
     #[test]
-    fn x014_guard_view_chain_three_views_fails() {
-        // A → B → C: A's target B has guard_view set → fail.
+    fn x014_guard_view_chain_of_three_passes() {
+        // A → B → C with C a leaf — chains are allowed up to MAX depth.
         let mut a = make_view_codecomponent(vec![]);
         a.guard_view = Some("b".into());
         let mut b = make_view_codecomponent(vec![]);
         b.guard_view = Some("c".into());
-        let c = make_view_codecomponent(vec![]); // C is a leaf — no guard_view.
+        let c = make_view_codecomponent(vec![]); // leaf
 
         let mut views = HashMap::new();
         views.insert("a".into(), a);
@@ -2169,8 +2213,172 @@ mod tests {
         );
         let bundle = make_bundle(vec![app]);
         let results = validate_crossref(&bundle);
+        assert!(!has_fail(&results, error_codes::X014),
+            "chain of three (A → B → C) should validate cleanly; got: {:?}",
+            results.iter().filter(|r| r.error_code.as_deref() == Some("X014"))
+                .map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn x014_guard_view_chain_at_max_depth_passes() {
+        // Chain of 5 hops past the protected view — at the cap.
+        // Protected ROOT → g1 → g2 → g3 → g4 → leaf
+        let mut root = make_view_codecomponent(vec![]);
+        root.guard_view = Some("g1".into());
+        let mut g1 = make_view_codecomponent(vec![]);
+        g1.guard_view = Some("g2".into());
+        let mut g2 = make_view_codecomponent(vec![]);
+        g2.guard_view = Some("g3".into());
+        let mut g3 = make_view_codecomponent(vec![]);
+        g3.guard_view = Some("g4".into());
+        let mut g4 = make_view_codecomponent(vec![]);
+        g4.guard_view = Some("leaf".into());
+        let leaf = make_view_codecomponent(vec![]);
+
+        let mut views = HashMap::new();
+        views.insert("root".into(), root);
+        views.insert("g1".into(), g1);
+        views.insert("g2".into(), g2);
+        views.insert("g3".into(), g3);
+        views.insert("g4".into(), g4);
+        views.insert("leaf".into(), leaf);
+
+        let app = make_app(
+            "test-app",
+            "app-service",
+            "00000000-0000-0000-0000-000000000001",
+            vec![],
+            vec![],
+            HashMap::new(),
+            HashMap::new(),
+            views,
+        );
+        let bundle = make_bundle(vec![app]);
+        let results = validate_crossref(&bundle);
+        assert!(!has_fail(&results, error_codes::X014),
+            "chain at MAX_GUARD_CHAIN_DEPTH (5) must validate; got: {:?}",
+            results.iter().filter(|r| r.error_code.as_deref() == Some("X014"))
+                .map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn x014_guard_view_chain_exceeds_max_depth_fails() {
+        // Chain of 6 hops past the protected view — over the cap.
+        // root → g1 → g2 → g3 → g4 → g5 → leaf
+        let mut root = make_view_codecomponent(vec![]);
+        root.guard_view = Some("g1".into());
+        let mut g1 = make_view_codecomponent(vec![]);
+        g1.guard_view = Some("g2".into());
+        let mut g2 = make_view_codecomponent(vec![]);
+        g2.guard_view = Some("g3".into());
+        let mut g3 = make_view_codecomponent(vec![]);
+        g3.guard_view = Some("g4".into());
+        let mut g4 = make_view_codecomponent(vec![]);
+        g4.guard_view = Some("g5".into());
+        let mut g5 = make_view_codecomponent(vec![]);
+        g5.guard_view = Some("leaf".into());
+        let leaf = make_view_codecomponent(vec![]);
+
+        let mut views = HashMap::new();
+        views.insert("root".into(), root);
+        views.insert("g1".into(), g1);
+        views.insert("g2".into(), g2);
+        views.insert("g3".into(), g3);
+        views.insert("g4".into(), g4);
+        views.insert("g5".into(), g5);
+        views.insert("leaf".into(), leaf);
+
+        let app = make_app(
+            "test-app",
+            "app-service",
+            "00000000-0000-0000-0000-000000000001",
+            vec![],
+            vec![],
+            HashMap::new(),
+            HashMap::new(),
+            views,
+        );
+        let bundle = make_bundle(vec![app]);
+        let results = validate_crossref(&bundle);
         assert!(has_fail(&results, error_codes::X014),
-            "expected X014 for deep chain (A → B → C)");
+            "chain of 6 must trip the depth cap");
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("X014")
+                && r.message.contains("exceeds MAX_GUARD_CHAIN_DEPTH")
+        ), "expected depth-cap error message");
+    }
+
+    #[test]
+    fn x014_guard_view_chain_codecomponent_check_at_every_hop() {
+        // Chain hop 2 (B) is a DataView — must fail at validate even
+        // though hop 1 (A) is a clean codecomponent.
+        let mut dataviews = HashMap::new();
+        dataviews.insert("dv1".into(), make_dv_config("dv1", "db"));
+
+        let mut a = make_view_codecomponent(vec![]);
+        a.guard_view = Some("b".into());
+        let b = make_view_dataview("Rest", "dv1"); // DataView handler — not codecomponent.
+        let mut protected = make_view_codecomponent(vec![]);
+        protected.guard_view = Some("a".into());
+
+        let mut views = HashMap::new();
+        views.insert("a".into(), a);
+        views.insert("b".into(), b);
+        views.insert("protected".into(), protected);
+
+        let mut datasources = HashMap::new();
+        datasources.insert("db".into(), make_ds_config("db", "faker"));
+
+        let app = make_app(
+            "test-app",
+            "app-service",
+            "00000000-0000-0000-0000-000000000001",
+            vec![make_resource_ds("db", "faker")],
+            vec![],
+            datasources,
+            dataviews,
+            views,
+        );
+        let bundle = make_bundle(vec![app]);
+        let results = validate_crossref(&bundle);
+        assert!(has_fail(&results, error_codes::X014),
+            "chain hop must be codecomponent, even past the head");
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("X014")
+                && r.message.contains("must be a codecomponent-handler view")
+        ), "expected per-hop codecomponent rejection");
+    }
+
+    #[test]
+    fn w009_fires_on_chain_hop_with_session_auth() {
+        // Chain hop B has auth = "session" — should warn even though
+        // it's not the head of the chain.
+        let mut a = make_view_codecomponent(vec![]);
+        a.guard_view = Some("b".into());
+        let mut b = make_view_codecomponent(vec![]);
+        b.auth = Some("session".into());
+        let mut protected = make_view_codecomponent(vec![]);
+        protected.guard_view = Some("a".into());
+
+        let mut views = HashMap::new();
+        views.insert("a".into(), a);
+        views.insert("b".into(), b);
+        views.insert("protected".into(), protected);
+
+        let app = make_app(
+            "test-app",
+            "app-service",
+            "00000000-0000-0000-0000-000000000001",
+            vec![],
+            vec![],
+            HashMap::new(),
+            HashMap::new(),
+            views,
+        );
+        let bundle = make_bundle(vec![app]);
+        let results = validate_crossref(&bundle);
+        assert!(has_warn(&results, error_codes::W009),
+            "expected W009 when a chain hop has auth = \"session\"");
     }
 
     // ── W009 guard target has auth = "session" (CB-P1.10 Plan H.5) ───

--- a/crates/riversd/src/security_pipeline.rs
+++ b/crates/riversd/src/security_pipeline.rs
@@ -238,22 +238,37 @@ pub async fn run_security_pipeline(
     })
 }
 
-// ── Named guard pre-flight (CB-P1.10 Plan H) ─────────────────────────
+// ── Named guard pre-flight (CB-P1.10 Plan H + chain lift) ────────────
 
-/// Run a per-view named guard's codecomponent before the view's
-/// primary handler dispatches.
+/// Maximum chain depth honoured at runtime. Defense-in-depth: validator
+/// already enforces this at config load (X014).
+const MAX_GUARD_CHAIN_DEPTH: usize = 5;
+
+/// Run the named-guard chain rooted at `initial_guard_view_name` before
+/// the protected view's primary handler dispatches.
 ///
 /// Honoured uniformly on every view type that flows through
 /// `view_dispatch_handler` — REST, streaming REST, MCP, WebSocket, SSE.
-/// The guard handler receives a `ParsedRequest` with the original
-/// method, path, and headers; the view's body has not been consumed
-/// yet (auth-shape decisions only).
 ///
-/// Returns `Ok(())` if the guard returned `{ allow: true }`. Returns
-/// `Err(Response)` with HTTP 401 when the guard rejected, the named
-/// view is missing at runtime (X014 should have caught this; defensive
-/// fallback), the named view is not a codecomponent, or the guard
-/// dispatcher itself errored.
+/// **Chain semantics:** if the named guard view itself declares a
+/// `guard_view`, the framework walks the chain inside-out — deepest
+/// leaf runs first, then each layer back up. Every level must return
+/// `{ allow: true }` for the request to proceed; the first rejection
+/// short-circuits the request with HTTP 401.
+///
+/// Each guard handler receives an independent `ParsedRequest` snapshot
+/// (method, path, headers, path_params); the protected view's body has
+/// not been consumed yet (auth-shape decisions only). `session_claims`
+/// returned by guards in the chain are not propagated to the protected
+/// view in v1 — that's a separate feature; the chain lift focuses on
+/// composition of allow/deny decisions.
+///
+/// Errors:
+/// - missing bundle / app / view at runtime → 500 (defensive fallback;
+///   validator should have caught these at config load)
+/// - cycle detected at runtime → 500 (defensive)
+/// - depth exceeded at runtime → 500 (defensive)
+/// - any guard returns `allow: false` or dispatcher errors → 401
 pub async fn run_named_guard_preflight(
     ctx: &crate::server::AppContext,
     app_entry_point: &str,
@@ -261,6 +276,128 @@ pub async fn run_named_guard_preflight(
     method: String,
     path: String,
     headers_map: HashMap<String, String>,
+    initial_guard_view_name: &str,
+) -> Result<(), axum::response::Response> {
+    // 1. Walk the chain to collect guard names in outermost-first order.
+    let chain = build_guard_chain(ctx, app_entry_point, initial_guard_view_name)?;
+
+    // 2. Reverse to dispatch deepest-leaf-first.
+    let dispatch_order: Vec<String> = chain.into_iter().rev().collect();
+
+    // 3. Dispatch each guard in order. First rejection short-circuits.
+    for guard_name in &dispatch_order {
+        dispatch_one_guard(
+            ctx,
+            app_entry_point,
+            path_params,
+            &method,
+            &path,
+            &headers_map,
+            guard_name,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Walk from the initial guard view following each target's
+/// `guard_view`, collecting names in outermost-first order. Returns the
+/// chain or a 401/500 response if the chain is malformed at runtime.
+fn build_guard_chain(
+    ctx: &crate::server::AppContext,
+    app_entry_point: &str,
+    initial_guard_view_name: &str,
+) -> Result<Vec<String>, axum::response::Response> {
+    use crate::error_response;
+
+    let bundle = match ctx.loaded_bundle.as_ref() {
+        Some(b) => b,
+        None => {
+            tracing::error!(
+                guard_view = %initial_guard_view_name,
+                "named guard pre-flight: no bundle loaded"
+            );
+            return Err(error_response::internal_error(
+                "named guard pre-flight: bundle not loaded",
+            )
+            .into_axum_response()
+            .into_response());
+        }
+    };
+    let app = bundle.apps.iter().find(|a| {
+        a.manifest.entry_point.as_deref() == Some(app_entry_point)
+            || a.manifest.app_entry_point.as_deref() == Some(app_entry_point)
+    });
+    let Some(app) = app else {
+        return Err(error_response::internal_error(
+            "named guard pre-flight: app not found in bundle",
+        )
+        .into_axum_response()
+        .into_response());
+    };
+
+    let mut chain: Vec<String> = Vec::new();
+    let mut current = initial_guard_view_name.to_string();
+    loop {
+        if chain.len() >= MAX_GUARD_CHAIN_DEPTH {
+            tracing::error!(
+                guard_view = %initial_guard_view_name,
+                depth = chain.len(),
+                "named guard chain exceeds runtime depth cap (validator should have caught this)"
+            );
+            return Err(error_response::internal_error(
+                "named guard chain exceeds depth cap",
+            )
+            .into_axum_response()
+            .into_response());
+        }
+        if chain.contains(&current) {
+            tracing::error!(
+                guard_view = %initial_guard_view_name,
+                cycle_at = %current,
+                "named guard chain has a cycle (validator should have caught this)"
+            );
+            return Err(error_response::internal_error(
+                "named guard chain forms a cycle",
+            )
+            .into_axum_response()
+            .into_response());
+        }
+
+        match app.config.api.views.get(current.as_str()) {
+            Some(target) => {
+                chain.push(current.clone());
+                match &target.guard_view {
+                    Some(next) => current = next.clone(),
+                    None => break,
+                }
+            }
+            None => {
+                tracing::error!(
+                    guard_view = %current,
+                    app = %app_entry_point,
+                    "named guard pre-flight: chain hop not found at runtime",
+                );
+                return Err(error_response::unauthorized("named guard not configured")
+                    .into_axum_response()
+                    .into_response());
+            }
+        }
+    }
+
+    Ok(chain)
+}
+
+/// Dispatch a single guard view's codecomponent and return Ok(()) on
+/// `allow: true`, Err(401) otherwise.
+async fn dispatch_one_guard(
+    ctx: &crate::server::AppContext,
+    app_entry_point: &str,
+    path_params: &HashMap<String, String>,
+    method: &str,
+    path: &str,
+    headers_map: &HashMap<String, String>,
     guard_view_name: &str,
 ) -> Result<(), axum::response::Response> {
     use rivers_runtime::view::HandlerConfig;
@@ -271,10 +408,6 @@ pub async fn run_named_guard_preflight(
         let bundle = match ctx.loaded_bundle.as_ref() {
             Some(b) => b,
             None => {
-                tracing::error!(
-                    guard_view = %guard_view_name,
-                    "named guard pre-flight: no bundle loaded"
-                );
                 return Err(error_response::internal_error(
                     "named guard pre-flight: bundle not loaded",
                 )
@@ -324,11 +457,11 @@ pub async fn run_named_guard_preflight(
     };
 
     let parsed = crate::view_engine::ParsedRequest {
-        method,
-        path,
+        method: method.to_string(),
+        path: path.to_string(),
         query_params: HashMap::new(),
         query_all: HashMap::new(),
-        headers: headers_map,
+        headers: headers_map.clone(),
         body: serde_json::Value::Null,
         path_params: path_params.clone(),
     };

--- a/docs/arch/rivers-mcp-view-spec.md
+++ b/docs/arch/rivers-mcp-view-spec.md
@@ -761,11 +761,16 @@ cross-cutting contract.
 
 | Code | Severity | What it catches |
 |---|---|---|
-| `X014` | error | `guard_view` references a missing view |
-| `X014` | error | `guard_view` target is not a codecomponent (DataView / `none` handlers can't return the `{ allow }` envelope) |
-| `X014` | error | `guard_view` target itself declares a `guard_view` (chains forbidden in v1: catches self-reference, mutual recursion, deep chains in one rule) |
-| `W009` | warning | `guard_view` target has `auth = "session"` — sessions don't exist when the guard runs |
-| `W010` | warning | View has both `guard = true` (server-wide gate) and `guard_view = "..."` (per-view gate) |
+| `X014` | error | `guard_view` (or any chain hop) references a missing view |
+| `X014` | error | `guard_view` (or any chain hop) target is not a codecomponent |
+| `X014` | error | Chain forms a cycle (self-reference, mutual recursion, longer cycle) |
+| `X014` | error | Chain exceeds `MAX_GUARD_CHAIN_DEPTH` (5 hops) |
+| `W009` | warning | Any chain hop has `auth = "session"` |
+| `W010` | warning | View has both `guard = true` and `guard_view` |
+
+**Chain composition:** a guard view may itself declare `guard_view`
+to compose multi-stage auth — see `rivers-view-layer-spec.md` §14.4
+for semantics, depth cap, and claims-propagation rules.
 
 ---
 

--- a/docs/arch/rivers-view-layer-spec.md
+++ b/docs/arch/rivers-view-layer-spec.md
@@ -884,17 +884,75 @@ guard_view = "user_guard"
 # no guard_view — public.
 ```
 
-### 14.4 Constraints (validator-enforced)
+### 14.4 Chain composition
+
+A guard view may itself declare `guard_view` to compose multi-stage
+auth. Chains run **inside-out** — deepest leaf first, then each layer
+back up to the protected view. Every level must return
+`{ allow: true }` for the request to proceed; the first rejection
+short-circuits with HTTP 401.
+
+```toml
+# Multi-tenant: validate token → check role → reach the protected route.
+[api.views.tenant_auth]
+view_type = "Rest"
+auth      = "none"
+[api.views.tenant_auth.handler]
+type       = "codecomponent"
+module     = "handlers/tenant.ts"
+entrypoint = "validate_token"
+language   = "typescript"
+
+[api.views.tenant_admin_check]
+view_type  = "Rest"
+auth       = "none"
+guard_view = "tenant_auth"            # depth 1
+[api.views.tenant_admin_check.handler]
+type       = "codecomponent"
+module     = "handlers/tenant.ts"
+entrypoint = "require_admin"
+language   = "typescript"
+
+[api.views.admin_orders]
+guard_view = "tenant_admin_check"     # depth 2
+```
+
+For a request to `admin_orders`:
+
+1. `tenant_auth` runs (deepest leaf). On `allow: true`, proceed.
+2. `tenant_admin_check` runs. On `allow: true`, proceed.
+3. `admin_orders` handler runs.
+
+Any level returning `allow: false` rejects the request immediately.
+
+**Chain limits:**
+
+- Maximum depth: **5** hops past the protected view (a constant in
+  `crates/riversd/src/security_pipeline.rs`). Validator rejects deeper
+  chains at config load with `X014`. Runtime check is
+  defense-in-depth.
+- Cycles forbidden. Validator catches self-reference (V → V), mutual
+  recursion (A → B → A), and longer cycles via DFS visited tracking.
+  Runtime check is defense-in-depth.
+
+**Claims propagation (v1):** `session_claims` returned by guards in
+the chain are **not** propagated to the protected view's
+`ctx.session`. The chain composes allow/deny decisions only. Cross-level
+claim merging is a separate feature; if a chain needs to share data
+between levels, use `ctx.store` or pass via headers.
+
+### 14.5 Constraints (validator-enforced)
 
 | Code | Severity | Catches |
 |---|---|---|
-| `X014` | error | `guard_view` references a missing view |
-| `X014` | error | `guard_view` target is not a codecomponent (DataView / `none` handlers can't return the `{ allow }` envelope) |
-| `X014` | error | `guard_view` target itself declares `guard_view` — **chains are not supported in v1.** Catches self-reference (V → V), mutual recursion (A → B → A), and arbitrarily deep chains in one rule. Lift in a follow-up PR if a real chained-auth use case surfaces. |
-| `W009` | warning | `guard_view` target has `auth = "session"` — sessions don't exist when the guard runs |
-| `W010` | warning | View has both `guard = true` (server-wide gate) and `guard_view = "..."` (per-view gate) |
+| `X014` | error | `guard_view` (or any chain hop) references a missing view |
+| `X014` | error | `guard_view` (or any chain hop) target is not a codecomponent (DataView / `none` handlers can't return the `{ allow }` envelope) |
+| `X014` | error | Chain forms a cycle — self-reference (V → V), mutual recursion (A → B → A), or a longer cycle |
+| `X014` | error | Chain exceeds `MAX_GUARD_CHAIN_DEPTH` (5 hops) |
+| `W009` | warning | Any chain hop has `auth = "session"` — sessions don't exist when the guard runs |
+| `W010` | warning | Protected view has both `guard = true` (server-wide gate) and `guard_view = "..."` (per-view gate) |
 
-### 14.5 Cross-references
+### 14.6 Cross-references
 
 - `rivers-mcp-view-spec.md` §13.5 — MCP-specific config example.
 - `rivers-auth-session-spec.md` §11.5 — bearer-token recipe via a named guard (closes CB-P1.12).

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2026-05-08 — Lift v1 chain prohibition for guard_view
+
+`guard_view` chains are now allowed up to `MAX_GUARD_CHAIN_DEPTH`
+(5 hops past the protected view). The validator's "target must not
+declare guard_view" prohibition is replaced with cycle detection
+(DFS visited set) + depth cap. The runtime walks the chain
+inside-out (deepest leaf first) and short-circuits on the first
+`allow: false` with HTTP 401.
+
+Multi-tenant deployments can now compose auth stages — e.g.
+`token_validate → role_check → resource_check` — without collapsing
+all logic into one handler.
+
+| File | Change | Spec ref | Notes |
+|------|--------|----------|-------|
+| `crates/rivers-runtime/src/validate_crossref.rs` | Chain walker replaces v1 prohibition; per-hop X014 + W009 checks; cycle + depth-cap rejections via X014. | CB-P1.10 follow-up | DFS visited tracking covers self-reference, mutual recursion, longer cycles. |
+| `crates/riversd/src/security_pipeline.rs` | `run_named_guard_preflight` refactored into `build_guard_chain` + `dispatch_one_guard`. Defensive runtime cycle/depth re-checks. | CB-P1.10 follow-up | Deepest-leaf-first dispatch order. |
+| `docs/arch/rivers-view-layer-spec.md` §14.4 | New "Chain composition" section with multi-tenant example. | | |
+| `docs/arch/rivers-mcp-view-spec.md` §13.5 | Constraint table updated. | | |
+| `todo/gutter.md` | Closed the "Lift v1 chain prohibition" deferred item. | | |
+| `Cargo.toml` (workspace) | Build-stamp-only bump (sprint-end policy). | CLAUDE.md versioning | |
+
+**Tests:** `cargo test -p rivers-runtime --lib` 256/256 (was 252;
++4 new tests, -1 renamed). 485/485 riversd lib (no regression).
+
+**v1 ships:** allow/deny composition only. **v1 does not ship:**
+session_claims propagation across chain levels — that has its own
+semantic decisions (merge order, key collisions, ctx.session
+visibility). If you need cross-level data flow, use `ctx.store` or
+headers in v1.
+
+---
+
 ## 2026-05-08 — Gutter cleanup: pre-existing test fixture fix + scope decisions
 
 Closes the `slow_observer_does_not_extend_request_latency` failure

--- a/todo/gutter.md
+++ b/todo/gutter.md
@@ -26,25 +26,17 @@ unusual. The slug-equivalent fix is already in place (line 89,
 the datasource-wiring extension until a real bundle author asks for
 it; the surface change isn't justified by speculation.
 
-## 2026-05-08 — Plan H follow-ups (deliberately deferred)
+## 2026-05-08 — Plan H follow-ups
 
-### Lift v1 chain prohibition
+### Closed: lift v1 chain prohibition
 
-Plan H rejected `guard_view` chains (target view declaring its own
-`guard_view`) at validate time with a single rule that catches
-self-reference, mutual recursion, and arbitrary depth. Multi-tenant
-deployments may eventually want chains (e.g. `tenant_auth →
-tenant_role_check`), but Plan H's multi-tenant motivation was
-per-route guards, not chained guards.
-
-**Why deferred:** lifting the prohibition is non-trivial. It requires
-(1) replacing the validator's chain-rejection rule with cycle
-detection (DFS, depth cap), (2) extending the runtime helper to
-dispatch chains transitively, (3) defining how `session_claims` from
-multiple guard levels merge, (4) spec section overhaul, (5)
-cross-level tests. ~2-3 hours of focused work that adds runtime
-complexity to solve a use case nobody has reported. Re-open when a
-real bundle authoring scenario surfaces.
+Shipped. `guard_view` chains are now allowed up to
+`MAX_GUARD_CHAIN_DEPTH` (5 hops). Validator replaces the chain
+prohibition with cycle detection (DFS visited set) + depth cap;
+runtime walks the chain inside-out (deepest leaf first) and
+short-circuits on the first `allow: false`. Claims propagation
+across chain levels remains v1-not-shipped — chains compose
+allow/deny decisions only.
 
 ### Per-view-type runtime tests for `guard_view`
 


### PR DESCRIPTION
## Summary

- `guard_view` chains are now allowed up to **`MAX_GUARD_CHAIN_DEPTH` (5 hops)** past the protected view. Plan H's blanket "target must not declare guard_view" rule is replaced with cycle detection (DFS visited set) + depth cap.
- Runtime walks the chain **inside-out (deepest leaf first)** and short-circuits on the first `allow: false` with HTTP 401. Deepest-first matches the intuition that base auth precedes role-specific checks.
- Multi-tenant deployments can compose auth stages — e.g. `token_validate → role_check → resource_check` — without collapsing all logic into one handler.

## Validator: chain walker

Replaces the inline `X014` chain rejection with a walker that:

- Tracks visited views in a HashSet → catches self-reference (V → V), mutual recursion (A → B → A), longer cycles
- Caps chain length at 5 hops past the protected view → deeper fails `X014`
- Re-applies per-hop `X014` (target exists, target is codecomponent)
- Re-applies per-hop `W009` (any hop with `auth = "session"` warns)
- `W010` still fires once at the chain head

## Runtime: helper refactor

`run_named_guard_preflight` is refactored into:

- `build_guard_chain` — walks the chain, returns outermost-first names. Defensive runtime cycle/depth re-checks return **500** (validator should have caught at config load).
- `dispatch_one_guard` — single-level dispatch (the previous helper's body, refactored to take borrows).
- `run_named_guard_preflight` — calls `build_guard_chain`, reverses for deepest-first dispatch, runs each via `dispatch_one_guard`. First `allow: false` short-circuits with HTTP 401.

## What ships in v1 vs not

**Ships:** allow/deny composition only.

**Does NOT ship:** `session_claims` propagation across chain levels. Each level's claims are local to that dispatch; the protected view doesn't see chain-internal claims. Cross-level data flow uses `ctx.store` or headers in v1. Claims propagation has its own semantic decisions (merge order, key collisions, `ctx.session` visibility) and is a separate feature.

Plan: `docs/superpowers/plans/2026-05-08-cb-mcp-followup-batch-2-h-rebuilt.md`.

## Test plan

- [x] `cargo test -p rivers-runtime --lib` — **256 passed** / 0 failed (was 252; +4 new, -1 renamed)
- [x] New tests cover: chain-of-3 passes, chain-at-depth-5 passes, chain-of-6 fails (depth cap), per-hop codecomponent check at every chain level, W009 fires on chain hops
- [x] Existing tests covering self-reference and mutual recursion updated to assert cycle-detection wording (still emit X014)
- [x] `cargo test -p riversd --lib` — **485 passed** / 0 failed (no regression)
- [x] Spec updates: `rivers-view-layer-spec.md` §14.4 (Chain composition) + §14.5 (constraint table); `rivers-mcp-view-spec.md` §13.5 aligned
- [x] Gutter: closed the "Lift v1 chain prohibition" deferred item
- [x] Build-stamp-only bump per sprint-end policy: `0.60.7+1909080526 → 0.60.7+2027080526`

🤖 Generated with [Claude Code](https://claude.com/claude-code)