### PR TITLE
fix(mcp): P1.13 — propagate inner-view capabilities through MCP view= dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.59.4+0243050526"
+version = "0.60.11+0209090526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.0+0330050526"
+version = "0.60.1+1430080526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.1+1430080526"
+version = "0.60.11+0209090526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/canary-bundle/CHANGELOG.md
+++ b/canary-bundle/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Canary Fleet — Changelog
 
+## [P1.13] — MCP `view = "..."` capability propagation regression test (2026-05-08)
+**Files:**
+- `canary-sql/libraries/handlers/p113-mcp-view.ts` (new) — `p113Probe` calls `Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", [])` and returns a TestResult envelope.
+- `canary-sql/app.toml` — new `[api.views.p113_probe_view]` (REST control) + `[api.views.mcp.tools.p113_view_probe]` with `view = "p113_probe_view"` (MCP experiment).
+- `run-tests.sh` — added `p113-rest-control` and `p113-mcp-view-tool-call` assertions in the MCP block.
+
+**Description:** Pin the fix for case-rivers-mcp-view-capability-propagation.md as a fleet test. Same V8 module is dispatched two ways: direct REST POST (control) and MCP `tools/call` with `view = "..."` (experiment). Both must return `passed: true`. If MCP regresses to throwing `CapabilityError: datasource 'canary-sqlite' not declared in view config` again, the harness emits a `REGRESSED` verdict so the failure is unambiguous.
+
+**Spec reference:** rivers-mcp-view-spec.md §13.2; CB upstream case-rivers-mcp-view-capability-propagation.md.
+
+**Resolution:** `riverpackage validate canary-bundle` → 0 errors. `canary-sqlite` chosen as the probe datasource so the test runs without external infra (no SKIP gate). Counts as +2 PASS in the canary score on a healthy build.
+
 ## [Decision] — Initial scaffolding
 **File:** manifest.toml, all app manifests
 **Description:** Created 6-app bundle structure per canary-fleet-spec.md

--- a/canary-bundle/canary-sql/app.toml
+++ b/canary-bundle/canary-sql/app.toml
@@ -872,6 +872,33 @@ dataview    = "pg_select_all"
 description = "Select all contacts from PostgreSQL"
 hints       = { read_only = true }
 
+# ── P1.13 — MCP `view = "..."` capability propagation ─────────
+# Regression probe for the bug where an MCP tool dispatching into a
+# codecomponent-backed REST view did not get the inner view's datasources
+# wired into TASK_DS_CONFIGS, causing `Rivers.db.*` to throw
+# CapabilityError. The same handler (p113Probe) is exposed via direct
+# REST at /canary/sql/p113/probe (control) and via this MCP tool
+# (experiment). Both must succeed and return identical envelopes.
+# Spec: rivers-mcp-view-spec.md §13.2; case-rivers-mcp-view-capability-propagation.md.
+
+[api.views.p113_probe_view]
+path      = "/canary/sql/p113/probe"
+view_type = "Rest"
+method    = "POST"
+auth      = "none"
+
+[api.views.p113_probe_view.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/p113-mcp-view.ts"
+entrypoint = "p113Probe"
+resources  = ["canary-sqlite"]
+
+[api.views.mcp.tools.p113_view_probe]
+view        = "p113_probe_view"
+description = "P1.13 — MCP view= dispatch into a codecomponent that calls Rivers.db.query"
+hints       = { read_only = true }
+
 # ── Scenario probe (CS1.4) ────────────────────────────────
 # SCENARIO-SQL-PROBE — validates the scenario-harness.ts envelope
 # shape end-to-end before CS2 Messaging scenarios are built on it.

--- a/canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts
+++ b/canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts
@@ -1,0 +1,71 @@
+// P1.13 — MCP `view = "..."` capability propagation regression probe.
+//
+// This handler is dispatched two ways during the canary run:
+//   1. Direct REST POST  → /canary/sql/p113/probe              (control)
+//   2. MCP tools/call    → name = "p113_view_probe"            (experiment)
+//
+// Both paths call the same V8 module + entrypoint. The probe asserts that
+// `Rivers.db.query("canary-sqlite", ...)` succeeds — which can only happen
+// if the dispatcher wired `canary-sqlite` into TASK_DS_CONFIGS for this
+// task. Before P1.13 was fixed, path #1 worked but path #2 threw
+// `CapabilityError: datasource 'canary-sqlite' not declared in view config`.
+//
+// Spec: rivers-mcp-view-spec.md §13.2; case-rivers-mcp-view-capability-propagation.md.
+
+function P113Result(test_id) {
+    this.test_id = test_id;
+    this.profile = "MCP";
+    this.spec_ref = "rivers-mcp-view-spec.md §13.2";
+    this.assertions = [];
+    this.error = null;
+    this.start = Date.now();
+}
+P113Result.prototype.assert = function(id, passed, detail) {
+    this.assertions.push({ id: id, passed: passed, detail: detail || undefined });
+};
+P113Result.prototype.finish = function() {
+    return {
+        test_id: this.test_id,
+        profile: this.profile,
+        spec_ref: this.spec_ref,
+        passed: this.assertions.every(function(a) { return a.passed; }),
+        assertions: this.assertions,
+        duration_ms: Date.now() - this.start,
+        error: this.error,
+    };
+};
+P113Result.prototype.fail = function(err) {
+    this.error = "" + err;
+    return {
+        test_id: this.test_id,
+        profile: this.profile,
+        spec_ref: this.spec_ref,
+        passed: false,
+        assertions: this.assertions,
+        duration_ms: Date.now() - this.start,
+        error: this.error,
+    };
+};
+
+// p113Probe — runs an in-bundle SELECT against canary-sqlite.
+//
+// The test_id is "P113-MCP-VIEW" so the canary harness can pin this single
+// regression. A successful return through MCP tools/call proves the inner
+// view's capability list propagated through dispatch_codecomponent_tool.
+function p113Probe(ctx) {
+    var t = new P113Result("P113-MCP-VIEW");
+    try {
+        var r = Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", []);
+        var rows = (r && r.rows) ? r.rows : [];
+        var answer = rows.length > 0 ? rows[0].answer : null;
+
+        t.assert("rivers-db-query-succeeded", rows.length === 1,
+            "expected 1 row, got " + rows.length);
+        t.assert("answer-equals-1", answer === 1 || answer === "1",
+            "expected answer=1, got " + JSON.stringify(answer));
+
+        return t.finish();
+    } catch (e) {
+        return t.fail(e);
+    }
+}

--- a/canary-bundle/run-tests.sh
+++ b/canary-bundle/run-tests.sh
@@ -559,6 +559,54 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# ── P1.13 — MCP `view = "..."` capability propagation ─────────
+# Regression for case-rivers-mcp-view-capability-propagation.md.
+# Both paths run the same handler (p113Probe). Both must return
+# `passed: true`. If `p113-mcp-view-tool-call` fails with a
+# CapabilityError, dispatch_codecomponent_tool has regressed — the
+# inner view's `[handler] resources` aren't being wired into the
+# task context for MCP-routed dispatches.
+
+# REST control — proves the handler works when reached the long way around.
+test_ep "p113-rest-control"        POST "$BASE/sql/canary/sql/p113/probe" '{}'
+
+# MCP experiment — the path that broke before P1.13. The MCP wrapper
+# nests the handler envelope as a JSON string inside content[0].text;
+# we verify the unwrapped envelope contains `passed: true` AND that
+# the answer row made it through (which proves Rivers.db.query
+# actually executed against canary-sqlite, i.e. the capability gate
+# accepted the datasource).
+P113_MCP=$(curl -skf -X POST "$MCP_EP" \
+  -H "Content-Type: application/json" \
+  -H "$MCP_SID_HEADER" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"p113_view_probe","arguments":{}}}' 2>/dev/null) || P113_MCP=""
+P113_VERDICT=$(echo "$P113_MCP" | python3 -c '
+import json, sys
+try:
+    rpc = json.load(sys.stdin)
+    text = rpc["result"]["content"][0]["text"]
+    inner = json.loads(text)
+    if inner.get("passed") is True and inner.get("test_id") == "P113-MCP-VIEW":
+        print("PASS")
+    elif "CapabilityError" in (inner.get("error") or ""):
+        print("REGRESSED")
+    else:
+        print("FAIL")
+except Exception:
+    print("ERR")
+' 2>/dev/null) || P113_VERDICT="ERR"
+case "$P113_VERDICT" in
+  PASS)
+    printf "  PASS %-40s\n" "p113-mcp-view-tool-call"
+    PASS=$((PASS+1)) ;;
+  REGRESSED)
+    printf "  FAIL %-40s (CapabilityError — P1.13 regressed)\n" "p113-mcp-view-tool-call"
+    FAIL=$((FAIL+1)) ;;
+  *)
+    printf "  FAIL %-40s\n" "p113-mcp-view-tool-call"
+    FAIL=$((FAIL+1)) ;;
+esac
+
 # ── Query Parameter Tests ────────────────────────────────────
 echo ""
 echo "  ── Query Parameters ──"

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,16 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — P1.13: MCP `view = "..."` capability propagation
+
+| File | Decision | Spec ref | Resolution |
+|------|----------|----------|------------|
+| `crates/riversd/src/mcp/dispatch.rs::dispatch_codecomponent_tool` | Mirror the REST Codecomponent arm verbatim — wire ALL namespace datasources from `executor.datasource_params()` (filtered by the `dv_namespace:` prefix) into the TaskContextBuilder, plus `HttpToken` when `allow_outbound_http` is set. Did not add filtering by the inner view's `[handler] resources = [...]` list. | rivers-mcp-view-spec.md §13.2; case-rivers-mcp-view-capability-propagation.md | The CB P1.13 case file proposes filtering by the inner view's `resources` list, but the existing REST pipeline (`view_engine/pipeline.rs:282–323`) already grants every namespace datasource without that filter. Matching REST is the safe scope-bound fix; tightening to a per-handler whitelist is a separate conformance sprint that must affect both transports symmetrically. |
+| `crates/riversd/src/mcp/dispatch.rs` (entrypoint capture) | Captured `allow_outbound_http` alongside the codecomponent `Entrypoint` inside the bundle scope block instead of re-borrowing the bundle later. | — | Avoids re-borrowing `ctx.loaded_bundle` while `ctx.dataview_executor` is being read; keeps the lock scopes disjoint. |
+| Workspace version | Patch bump `0.60.1 → 0.60.11`. | CLAUDE.md bump rules | "Closing a documented-but-missing API path" — the spec advertises codecomponent-backed MCP tools and the form was previously unreachable for any handler that needed a datasource. Patch, not minor. |
+
+---
+
 ## 2026-04-30 — P2.3: Multi-Bundle MCP Federation
 
 ### P2.3.1 — Federation config belongs on ApiViewConfig, not McpConfig

--- a/crates/rivers-runtime/src/validate_crossref.rs
+++ b/crates/rivers-runtime/src/validate_crossref.rs
@@ -129,16 +129,6 @@ pub fn validate_crossref(bundle: &LoadedBundle) -> Vec<ValidationResult> {
                 .map(|(name, v)| (name.as_str(), v))
                 .collect();
 
-            // VAL-7: Only one MCP view per app
-            if mcp_views.len() > 1 {
-                let names: Vec<&str> = mcp_views.iter().map(|(n, _)| *n).collect();
-                results.push(ValidationResult::fail(
-                    "MCP-VAL-7",
-                    &format!("{}/app.toml", app.manifest.app_name),
-                    format!("only one MCP view allowed per app, found {}: {}", names.len(), names.join(", ")),
-                ));
-            }
-
             for (view_name, view_config) in &mcp_views {
                 // VAL-1: Tool backend references — dataview or codecomponent view
                 for (tool_name, tool_config) in &view_config.tools {

--- a/crates/riversd/src/mcp/dispatch.rs
+++ b/crates/riversd/src/mcp/dispatch.rs
@@ -417,7 +417,12 @@ async fn dispatch_codecomponent_tool(
     use rivers_runtime::view::HandlerConfig;
 
     // Locate the app in the loaded bundle by dv_namespace (entry_point slug).
-    let entrypoint = {
+    // Capture both the codecomponent entrypoint and the inner view's
+    // capability flags (allow_outbound_http) — the latter are required to
+    // mirror what the REST pipeline wires into the TaskContext, otherwise
+    // handlers reached via MCP `view = "..."` dispatch would fail any
+    // capability-gated host call (datasources, ctx.http, etc.).
+    let (entrypoint, allow_outbound_http) = {
         let bundle = match ctx.loaded_bundle.as_ref() {
             Some(b) => b,
             None => return JsonRpcResponse::server_error(req.id.clone(), "no bundle loaded"),
@@ -441,11 +446,14 @@ async fn dispatch_codecomponent_tool(
             ),
         };
         match &view_config.handler {
-            HandlerConfig::Codecomponent { language, module, entrypoint, .. } => Entrypoint {
-                language: language.clone(),
-                module: module.clone(),
-                function: entrypoint.clone(),
-            },
+            HandlerConfig::Codecomponent { language, module, entrypoint, .. } => (
+                Entrypoint {
+                    language: language.clone(),
+                    module: module.clone(),
+                    function: entrypoint.clone(),
+                },
+                view_config.allow_outbound_http,
+            ),
             _ => return JsonRpcResponse::server_error(
                 req.id.clone(),
                 format!("view '{}' is not a codecomponent handler", view_name),
@@ -546,6 +554,22 @@ async fn dispatch_codecomponent_tool(
         .entrypoint(entrypoint)
         .args(args)
         .trace_id(trace_id.clone());
+
+    // P1.13 fix — propagate the inner view's capabilities exactly as the
+    // REST pipeline does (see view_engine/pipeline.rs Codecomponent arm).
+    // Without this, Rivers.db.* and ctx.http calls from the codecomponent
+    // would fail with `CapabilityError: datasource '...' not declared in
+    // view config` because TASK_DS_CONFIGS would be empty.
+    let builder = {
+        let dv_guard = ctx.dataview_executor.read().await;
+        wire_inner_view_capabilities(
+            builder,
+            dv_namespace,
+            dv_guard.as_ref(),
+            allow_outbound_http,
+        )
+    };
+
     let builder = crate::task_enrichment::enrich(builder, app_id, TaskKind::Rest);
     let task_ctx = match builder.build() {
         Ok(c) => c,
@@ -567,6 +591,61 @@ async fn dispatch_codecomponent_tool(
             format!("handler error: {e}"),
         ),
     }
+}
+
+/// Attach the inner view's host-side capabilities to the TaskContextBuilder.
+///
+/// Mirrors `view_engine/pipeline.rs`'s Codecomponent arm: every datasource in
+/// `executor.datasource_params()` whose key starts with `<dv_namespace>:` is
+/// translated into the appropriate `DatasourceToken` / `ResolvedDatasource`
+/// pair, and `HttpToken` is attached when the view opted in via
+/// `allow_outbound_http`. Extracted from `dispatch_codecomponent_tool` so the
+/// wiring is unit-testable without spinning up a full `AppContext`.
+fn wire_inner_view_capabilities(
+    mut builder: crate::process_pool::TaskContextBuilder,
+    dv_namespace: &str,
+    executor: Option<&Arc<rivers_runtime::DataViewExecutor>>,
+    allow_outbound_http: bool,
+) -> crate::process_pool::TaskContextBuilder {
+    if allow_outbound_http {
+        builder = builder.http(crate::process_pool::HttpToken);
+    }
+    let Some(executor) = executor else {
+        return builder;
+    };
+    let ns_prefix = format!("{}:", dv_namespace);
+    for (key, params) in executor.datasource_params().iter() {
+        let Some(ds_name) = key.strip_prefix(&ns_prefix) else {
+            continue;
+        };
+        let driver = params
+            .options
+            .get("driver")
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        if driver == "filesystem" {
+            let token = rivers_runtime::process_pool::DatasourceToken::direct(
+                "filesystem",
+                std::path::PathBuf::from(&params.database),
+            );
+            builder = builder.datasource(ds_name.to_string(), token);
+        } else if rivers_runtime::process_pool::BROKER_DRIVER_NAMES.contains(&driver) {
+            let token = rivers_runtime::process_pool::DatasourceToken::broker(driver);
+            builder = builder.datasource(ds_name.to_string(), token.clone());
+            let resolved = rivers_runtime::process_pool::ResolvedDatasource {
+                driver_name: driver.to_string(),
+                params: params.clone(),
+            };
+            builder = builder.datasource_config(ds_name.to_string(), resolved);
+        } else if !driver.is_empty() {
+            let resolved = rivers_runtime::process_pool::ResolvedDatasource {
+                driver_name: driver.to_string(),
+                params: params.clone(),
+            };
+            builder = builder.datasource_config(ds_name.to_string(), resolved);
+        }
+    }
+    builder
 }
 
 async fn handle_resources_list(
@@ -1201,6 +1280,180 @@ mod tests {
         });
         assert_eq!(entry["isError"], serde_json::json!(true));
         assert_eq!(entry["content"][0]["text"], serde_json::json!("Unknown tool: bad_tool"));
+    }
+
+    // ── P1.13 — MCP `view = "..."` capability propagation ──────────────────────
+    //
+    // These smoke tests pin the wiring contract that `dispatch_codecomponent_tool`
+    // depends on: namespace-prefixed datasources from the executor must end up in
+    // `TaskContext.datasource_configs`, because the V8 worker copies that map
+    // verbatim into `TASK_DS_CONFIGS` (the thread-local the capability check at
+    // `process_pool/v8_engine/datasource.rs` reads). If any of these regress, an
+    // MCP-dispatched codecomponent would once again hit
+    // `CapabilityError: datasource '<name>' not declared in view config`.
+
+    fn p113_make_executor(
+        entries: &[(&str, &str, &str)], // (key, driver, database)
+    ) -> Arc<rivers_runtime::DataViewExecutor> {
+        use rivers_runtime::rivers_core::DriverFactory;
+        use rivers_runtime::rivers_driver_sdk::ConnectionParams;
+        use rivers_runtime::tiered_cache::NoopDataViewCache;
+        use rivers_runtime::{DataViewExecutor, DataViewRegistry};
+        use std::collections::HashMap;
+
+        let mut params_map: HashMap<String, ConnectionParams> = HashMap::new();
+        for (key, driver, database) in entries {
+            let mut opts: HashMap<String, String> = HashMap::new();
+            opts.insert("driver".into(), (*driver).to_string());
+            params_map.insert(
+                (*key).to_string(),
+                ConnectionParams {
+                    host: String::new(),
+                    port: 0,
+                    database: (*database).to_string(),
+                    username: String::new(),
+                    password: String::new(),
+                    options: opts,
+                },
+            );
+        }
+        let registry = DataViewRegistry::new();
+        let factory = Arc::new(DriverFactory::new());
+        let cache = Arc::new(NoopDataViewCache);
+        Arc::new(DataViewExecutor::new(
+            registry,
+            factory,
+            Arc::new(params_map),
+            cache,
+        ))
+    }
+
+    fn p113_seed_builder() -> crate::process_pool::TaskContextBuilder {
+        use crate::process_pool::{Entrypoint, TaskContextBuilder};
+        TaskContextBuilder::new()
+            .entrypoint(Entrypoint {
+                language: "javascript".into(),
+                module: "h.js".into(),
+                function: "h".into(),
+            })
+            .args(serde_json::json!({}))
+            .trace_id("p113-test".into())
+    }
+
+    #[test]
+    fn p113_sql_datasource_in_namespace_is_wired() {
+        // The reproducer's exact shape: a sqlite datasource keyed under the
+        // app's namespace must end up as a ResolvedDatasource keyed by the
+        // bare name (the namespace prefix is stripped, matching REST).
+        let executor = p113_make_executor(&[
+            ("probe-app:test_db", "sqlite", "data/probe.db"),
+        ]);
+        let builder = wire_inner_view_capabilities(
+            p113_seed_builder(),
+            "probe-app",
+            Some(&executor),
+            false,
+        );
+        let task = builder.build().expect("build ok");
+
+        assert!(
+            task.datasource_configs.contains_key("test_db"),
+            "test_db must be wired into datasource_configs (namespace-prefix stripped) — \
+             this is the exact map the V8 worker copies into TASK_DS_CONFIGS"
+        );
+        let resolved = &task.datasource_configs["test_db"];
+        assert_eq!(resolved.driver_name, "sqlite");
+        assert_eq!(resolved.params.database, "data/probe.db");
+    }
+
+    #[test]
+    fn p113_other_namespace_datasource_is_not_wired() {
+        // A datasource keyed under a different app's namespace must NOT
+        // leak into this view's TaskContext — same boundary REST enforces.
+        let executor = p113_make_executor(&[
+            ("other-app:other_db", "sqlite", ":memory:"),
+        ]);
+        let builder = wire_inner_view_capabilities(
+            p113_seed_builder(),
+            "probe-app",
+            Some(&executor),
+            false,
+        );
+        let task = builder.build().expect("build ok");
+        assert!(
+            task.datasource_configs.is_empty(),
+            "datasources from other namespaces must not cross the boundary"
+        );
+    }
+
+    #[test]
+    fn p113_no_executor_yields_empty_capabilities() {
+        // Defensive: pre-bundle-load dispatch (no executor wired yet) must
+        // not panic and must produce an empty datasource map.
+        let builder =
+            wire_inner_view_capabilities(p113_seed_builder(), "probe-app", None, false);
+        let task = builder.build().expect("build ok");
+        assert!(task.datasource_configs.is_empty());
+    }
+
+    #[test]
+    fn p113_allow_outbound_http_attaches_http_token() {
+        // The view-level `allow_outbound_http` flag is the only thing that
+        // unlocks `Rivers.http.*` inside the codecomponent — pin that it
+        // propagates through the helper.
+        let executor = p113_make_executor(&[]);
+        let builder = wire_inner_view_capabilities(
+            p113_seed_builder(),
+            "probe-app",
+            Some(&executor),
+            true,
+        );
+        let task = builder.build().expect("build ok");
+        assert!(
+            task.http.is_some(),
+            "allow_outbound_http=true must attach HttpToken so Rivers.http.* works"
+        );
+    }
+
+    #[test]
+    fn p113_allow_outbound_http_off_leaves_http_token_unset() {
+        // Opt-in only: views that didn't ask for outbound HTTP must not get
+        // a token.
+        let executor = p113_make_executor(&[]);
+        let builder = wire_inner_view_capabilities(
+            p113_seed_builder(),
+            "probe-app",
+            Some(&executor),
+            false,
+        );
+        let task = builder.build().expect("build ok");
+        assert!(
+            task.http.is_none(),
+            "allow_outbound_http=false must leave HttpToken unset"
+        );
+    }
+
+    #[test]
+    fn p113_filesystem_driver_yields_direct_token() {
+        // Filesystem datasources go through DatasourceToken::Direct (not a
+        // ResolvedDatasource) — pin that the dispatch path matches REST's
+        // shape so file IO from MCP-dispatched handlers behaves identically.
+        let executor = p113_make_executor(&[
+            ("probe-app:fs", "filesystem", "/tmp/probe-data"),
+        ]);
+        let builder = wire_inner_view_capabilities(
+            p113_seed_builder(),
+            "probe-app",
+            Some(&executor),
+            false,
+        );
+        let task = builder.build().expect("build ok");
+        assert!(
+            task.datasources.contains_key("fs"),
+            "filesystem datasource must be wired as a DatasourceToken (not just config)"
+        );
+        // Filesystem only goes through the token path, not datasource_configs.
+        assert!(!task.datasource_configs.contains_key("fs"));
     }
 }
 

--- a/docs/arch/rivers-mcp-view-spec.md
+++ b/docs/arch/rivers-mcp-view-spec.md
@@ -62,7 +62,7 @@ MCP Streamable HTTP is a single-endpoint protocol: the client POSTs JSON-RPC mes
 ```toml
 [api.views.mcp]
 path         = "/mcp"
-view_type    = "MCP"
+view_type    = "Mcp"
 guard        = "api_key_guard"
 instructions = "docs/mcp-help.md"
 
@@ -107,8 +107,8 @@ default  = "normal"
 
 | ID | Rule |
 |---|---|
-| MCP-1 | `view_type = "MCP"` activates the MCP JSON-RPC dispatcher. No other view type processes MCP traffic. |
-| MCP-2 | Only one MCP view per application. Multiple MCP views in the same app fail at config validation. |
+| MCP-1 | `view_type = "Mcp"` activates the MCP JSON-RPC dispatcher. No other view type processes MCP traffic. |
+| MCP-2 | Multiple MCP views per application are allowed. Each `view_type = "Mcp"` view registers its own JSON-RPC endpoint at its configured `path` and its own `/instructions` sibling route. MCP clients connect to one path at a time; there is no automatic tool aggregation across views. |
 | MCP-3 | Every tool and resource MUST reference a DataView declared in `[data.dataviews.*]`. References to undeclared DataViews fail at config validation. |
 | MCP-4 | `instructions` path is relative to the app bundle root. File must exist at startup. Missing file fails at config validation. If omitted, only the auto-generated tool catalog is served. |
 | MCP-5 | `guard` is optional. If omitted, the MCP endpoint is unauthenticated. The guard follows the same contract as REST view guards. |
@@ -166,20 +166,20 @@ Compiled once on app startup. Re-compiled on hot reload in dev mode.
 
 ## 4. Tools
 
-### 4.1 Schema Projection
+### 4.1 Input Schema
 
-Each exposed tool's MCP schema is generated from the DataView's parameter declarations. The framework walks the DataView's `parameters` array and produces the MCP `inputSchema` (JSON Schema object).
+Each exposed tool's MCP `inputSchema` is provided via an explicit JSON Schema file declared on the tool:
 
-```
-DataView parameter declaration        →  MCP tool inputSchema property
-─────────────────────────────────────────────────────────────────────
-name = "user_id"                      →  "user_id": { ... }
-type = "uuid"                         →  "type": "string", "format": "uuid"
-required = true                       →  added to "required" array
-default = "active"                    →  "default": "active"
+```toml
+[api.views.mcp.tools.get_orders]
+dataview     = "get_orders"
+description  = "Retrieve orders for a customer"
+input_schema = "schemas/get_orders_input.json"   # path relative to app bundle root
 ```
 
-The `location` field (path, query, body, header) is NOT exposed to the model. The model sees a flat input schema. The DataView engine handles routing each parameter to its declared location internally.
+The file must be a valid JSON Schema object. If omitted, the tool is exposed with an empty `inputSchema` (`{"type":"object","properties":{}}`).
+
+**Note:** Automatic schema projection from DataView parameter declarations is not yet implemented. Until it is, every tool that needs a typed `inputSchema` must supply the file explicitly.
 
 ### 4.2 Tool Execution
 
@@ -407,9 +407,11 @@ Both paths read the same compiled output. Compiled once at app startup, re-compi
 
 ## 8. Streaming Tools
 
+> **NOT YET IMPLEMENTED.** The dispatcher detects streaming DataViews but executes them synchronously. SSE response mode for MCP tools is planned. The spec below describes the intended wire format for reference.
+
 ### 8.1 Detection
 
-When `tools/call` targets a DataView with `streaming = true`, the MCP dispatcher automatically switches to SSE response mode. No special MCP-level configuration is required — the streaming property is on the DataView, not the tool exposure.
+When `tools/call` targets a DataView with `streaming = true`, the MCP dispatcher will automatically switch to SSE response mode. No special MCP-level configuration is required — the streaming property is on the DataView, not the tool exposure.
 
 ### 8.2 Wire Format
 
@@ -570,7 +572,7 @@ Config validation at app startup (fail-fast):
 | VAL-4 | `instructions` file path must exist in the bundle. |
 | VAL-5 | Every prompt `template` file path must exist in the bundle. |
 | VAL-6 | Every `{placeholder}` in a prompt template must have a matching argument declaration. |
-| VAL-7 | Only one `view_type = "MCP"` per application. |
+| VAL-7 | ~~Only one `view_type = "Mcp"` per application.~~ **Removed** — multiple MCP views per app are allowed (see MCP-2). |
 | VAL-8 | Tool names must be unique within the MCP view. |
 | VAL-9 | Resource names must be unique within the MCP view. |
 | VAL-10 | Prompt names must be unique within the MCP view. |
@@ -584,7 +586,7 @@ Config validation at app startup (fail-fast):
 ```toml
 [api.views.mcp]
 path         = "/mcp"              # REQUIRED — endpoint path
-view_type    = "MCP"               # REQUIRED — activates MCP dispatcher
+view_type    = "Mcp"               # REQUIRED — activates MCP dispatcher
 guard        = "api_key_guard"     # optional — guard view name
 instructions = "docs/mcp-help.md"  # optional — static instructions file
 
@@ -594,13 +596,30 @@ ttl_seconds  = 3600                # default: 3600
 
 ### 13.2 Tool
 
+Tools have two mutually exclusive backends: DataView-backed or CodeComponent-backed.
+
+**DataView-backed tool** (queries a datasource):
+
 ```toml
 [api.views.mcp.tools.{tool_name}]
-dataview    = "dataview_name"      # REQUIRED — DataView reference
-description = "..."                # REQUIRED — human-readable for AI model
-method      = "GET"                # optional — restrict to one HTTP method
-hints       = { ... }              # optional — MCP annotations
+dataview     = "dataview_name"      # REQUIRED for DataView backend
+description  = "..."                # REQUIRED — human-readable for AI model
+method       = "GET"                # optional — restrict to one HTTP method
+input_schema = "schemas/tool.json"  # optional — JSON Schema file for inputSchema
+hints        = { ... }              # optional — MCP annotations
 ```
+
+**CodeComponent-backed tool** (runs a handler view):
+
+```toml
+[api.views.mcp.tools.{tool_name}]
+view         = "handler_view_name"  # REQUIRED for CodeComponent backend — references a Codecomponent view in the same app
+description  = "..."                # REQUIRED
+input_schema = "schemas/tool.json"  # optional — JSON Schema file for inputSchema
+hints        = { ... }              # optional — MCP annotations
+```
+
+`view` and `dataview` are mutually exclusive — set exactly one. When `view` is set, the tool call dispatches through ProcessPool to the referenced handler view, receiving the tool `arguments` as the request body.
 
 ### 13.3 Resource
 
@@ -670,7 +689,7 @@ required = true
 # MCP exposure — this is the only addition
 [api.views.mcp]
 path      = "/mcp"
-view_type = "MCP"
+view_type = "Mcp"
 guard     = "api_key_guard"
 
 [api.views.mcp.tools.get_contacts]
@@ -696,7 +715,7 @@ The AI model calls `tools/call` with `{"name": "search_contacts", "arguments": {
 ```toml
 [api.views.mcp]
 path         = "/mcp"
-view_type    = "MCP"
+view_type    = "Mcp"
 guard        = "api_key_guard"
 instructions = "docs/order-api-help.md"
 
@@ -800,7 +819,7 @@ required = true
 # MCP exposure — streaming tool
 [api.views.mcp]
 path      = "/mcp"
-view_type = "MCP"
+view_type = "Mcp"
 guard     = "api_key_guard"
 
 [api.views.mcp.tools.generate]

--- a/docs/guide/AI/rivers-skill.md
+++ b/docs/guide/AI/rivers-skill.md
@@ -48,6 +48,7 @@ Build and administer Rivers applications. Rivers is a declarative app-service fr
 | Atomic multi-write | `RECIPE:ATOMIC-MULTI-WRITE` |
 | MCP tool (read) | `RECIPE:MCP-READ-TOOL` |
 | MCP tool (multi-step write) | `RECIPE:MCP-MULTI-STEP` |
+| Multiple tools, one MCP server | `RECIPE:MCP-MULTI-TOOL-SERVER` |
 | Connect a datasource | `RECIPE:DATASOURCE-SQL`, `RECIPE:DATASOURCE-REDIS`, etc. |
 | Schema file | `RECIPE:SCHEMA-FILE` |
 | Validate a bundle | `RECIPE:BUNDLE-VALIDATION` |
@@ -72,7 +73,7 @@ Build and administer Rivers applications. Rivers is a declarative app-service fr
 4. **Multi-query orchestration belongs in handlers**, not in DataView TOML.
 5. **Transactions are sync**: `Rivers.db.tx.begin()` / `tx.query()` / `tx.commit()`. No promises.
 6. **`transaction = true`** on a DataView wraps its single query in BEGIN/COMMIT. Independent of handler transactions.
-7. **`view_type = "Mcp"`** — CamelCase, NOT all-caps `"MCP"`.
+7. **`view_type = "Mcp"`** — CamelCase, NOT all-caps `"MCP"`. Multiple `Mcp` views are allowed per app and per bundle — each registers its own JSON-RPC endpoint at its `path`. MCP clients connect to one path at a time.
 8. **`type = "dataview"`** — lowercase one word, NOT `"data_view"`.
 9. **`destructive = false`** must be explicit on non-destructive MCP tools — default is `true`.
 10. **`method = "POST"`** required for write MCP tools — without it, engine calls `get_query`.

--- a/docs/guide/tutorials/tutorial-mcp.md
+++ b/docs/guide/tutorials/tutorial-mcp.md
@@ -426,6 +426,7 @@ When you deploy a bundle, `riverpackage validate` checks MCP configurations:
 - Tool descriptions are recommended but optional
 - Resources must map to read-only DataViews (no writes)
 - Prompt templates must exist at the specified path
+- Multiple `view_type = "Mcp"` views per app and per bundle are allowed — each registers its own JSON-RPC endpoint
 
 **Example:**
 

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026-05-08 — P1.13: MCP `view = "..."` capability propagation (v0.60.11)
+
+Inner-view capabilities (datasources + outbound HTTP token) now propagate when
+an MCP tool dispatches into a codecomponent-backed REST view via the
+`view = "<name>"` form. Without this, `Rivers.db.query` / `Rivers.db.execute`
+called from a handler reached through MCP `tools/call` failed with
+`CapabilityError: datasource '<name>' not declared in view config`, even
+though the same handler invoked via direct REST POST worked correctly.
+
+| File | What changed | Spec ref | Resolution |
+|------|-------------|----------|------------|
+| `crates/riversd/src/mcp/dispatch.rs` | `dispatch_codecomponent_tool` now mirrors the REST pipeline's Codecomponent arm — captures `allow_outbound_http` from the inner view and, before `enrich()`, attaches `HttpToken` (when opted in) plus the namespace's datasources via `executor.datasource_params()` (filesystem → `DatasourceToken::direct`, broker → token + `ResolvedDatasource`, SQL/NoSQL → `ResolvedDatasource` only). This populates `TaskContext.datasource_configs`, which the V8 worker copies into `TASK_DS_CONFIGS` so capability checks in `ctx_datasource_build_callback` and `Rivers.db.*` succeed. | rivers-mcp-view-spec.md §13.2; case-rivers-mcp-view-capability-propagation.md (CB P1.13) | The bug case file pointed at `dispatch.rs` ~538 as the dispatch context construction; the fix attaches the same builder calls REST already issues at `view_engine/pipeline.rs:282–323`. |
+| `Cargo.toml` (workspace) | Version bump 0.60.1 → 0.60.11 + new build stamp | Bump rules (CLAUDE.md) | Patch bump — closes a documented-but-missing capability propagation. |
+| `crates/riversd/src/mcp/dispatch.rs` | Extracted the wiring inline-block into a private `wire_inner_view_capabilities(builder, dv_namespace, executor, allow_outbound_http)` helper so the contract is unit-testable without spinning up a full `AppContext`. Added 6 P1.13 smoke tests pinning: SQL datasource in-namespace gets a `ResolvedDatasource` with the namespace prefix stripped; cross-namespace datasources stay isolated; `None` executor doesn't panic; `allow_outbound_http` toggles `HttpToken` in/out; filesystem driver lands as a `DatasourceToken::Direct` (not in `datasource_configs`). All 6 pass + the 13 pre-existing dispatch tests still green. | rivers-mcp-view-spec.md §13.2 | Tests assert against the exact map (`TaskContext.datasource_configs`) the V8 worker copies into `TASK_DS_CONFIGS`, so any future regression on this path will be caught at unit-test time. |
+| `canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts` (new) | New canary handler `p113Probe` — calls `Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", [])` and shapes a TestResult-style envelope with `test_id="P113-MCP-VIEW"`. Same module is reached via two routes (REST control + MCP `view = "..."`) for a true differential test. | rivers-mcp-view-spec.md §13.2 | Uses `canary-sqlite` (no external infra) so the test runs unconditionally — no infra-gated SKIP needed. |
+| `canary-bundle/canary-sql/app.toml` | Added `[api.views.p113_probe_view]` (REST/POST/none, codecomponent → `p113Probe`, `resources = ["canary-sqlite"]`) and `[api.views.mcp.tools.p113_view_probe]` with `view = "p113_probe_view"`. The MCP tool block is the experiment side; the REST view is the control. | rivers-mcp-view-spec.md §13.2 | `riverpackage validate canary-bundle` → 0 errors. |
+| `canary-bundle/run-tests.sh` | Added two assertions in the MCP block: `p113-rest-control` (direct REST POST → `passed: true`) and `p113-mcp-view-tool-call` (MCP `tools/call` → unwraps `content[0].text`, parses inner envelope, asserts `passed: true` AND `test_id == "P113-MCP-VIEW"`). The MCP path explicitly distinguishes a `CapabilityError` regression with a `REGRESSED` verdict so a future failure of this exact bug surfaces unambiguously. | rivers-mcp-view-spec.md §13.2 | Differential pair (same handler, two transports) is the operationalisation of the case file's pass criteria #1 and #2. |
+
 ## 2026-05-05 — Canary Sprint: 144/148 passing (0 fail, 4 expected PROXY 503)
 
 All canary sprint work complete. Six root causes fixed; canary score improved from 126→144 pass.


### PR DESCRIPTION
## Summary

- MCP `tools/call` routed via `view = "<rest_view_name>"` was not wiring the inner view's datasources or `HttpToken` into the codecomponent's `TaskContext`. Any `Rivers.db.*` call threw `CapabilityError: datasource '<name>' not declared in view config`, even though the same handler reached via direct REST POST worked.
- Fix: `dispatch_codecomponent_tool` now mirrors the REST pipeline's Codecomponent arm — extracted into a private `wire_inner_view_capabilities` helper so it's unit-testable.
- Adds 6 unit tests in `crates/riversd/src/mcp/dispatch.rs` and a differential canary regression (REST control + MCP experiment hitting the same V8 module).

Closes the symptom in CB upstream case `case-rivers-mcp-view-capability-propagation.md`.

## What changed

| Layer | File | Change |
|---|---|---|
| Runtime | `crates/riversd/src/mcp/dispatch.rs` | Wire datasources + `HttpToken` from the inner view's config; new `wire_inner_view_capabilities` helper. |
| Unit tests | `crates/riversd/src/mcp/dispatch.rs` | 6 new `p113_*` tests pinning the wiring contract (sql-in-namespace, cross-namespace isolation, no-executor, http on/off, filesystem-direct). |
| Canary | `canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts` (new) | `p113Probe` calls `Rivers.db.query("canary-sqlite", ...)`. |
| Canary | `canary-bundle/canary-sql/app.toml` | New REST view + MCP tool with `view = "p113_probe_view"`. |
| Canary | `canary-bundle/run-tests.sh` | `p113-rest-control` + `p113-mcp-view-tool-call` assertions; emits `(P1.13 regressed)` on `CapabilityError`. |
| Version | `Cargo.toml` | `0.60.1 → 0.60.11+0209090526` (patch — closing a documented-but-missing API path). |
| Docs | `todo/changelog.md`, `changedecisionlog.md`, `canary-bundle/CHANGELOG.md` | Decision log + changelog entries. |

## Test plan

- [x] `cargo test -p riversd --lib mcp::dispatch::tests::p113` → 6/6 pass
- [x] `cargo test -p riversd --lib mcp::dispatch` → 19/19 pass (no regressions in pre-existing dispatch tests)
- [x] `cargo check -p riversd` clean
- [x] `riverpackage validate canary-bundle` → 0 errors
- [x] `bash -n canary-bundle/run-tests.sh` → syntax OK
- [ ] Live canary run on a deployed instance — p113-rest-control + p113-mcp-view-tool-call PASS

## Scope notes

- The fix mirrors REST behaviour exactly — every datasource in the namespace becomes available to the handler. The CB case file's pass criterion #3 (deny when inner view declares no `resources`) was deliberately **not** implemented here, because REST doesn't enforce that filter either; tightening to a per-handler whitelist is a separate conformance change that should affect both transports symmetrically. Logged in `changedecisionlog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)