### PR TITLE
fix(mcp): P1.13 follow-up — propagate HttpToken + canary regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "clap",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "chrono",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "chrono",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-nats",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -5990,7 +5990,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "age",
  "async-trait",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-trait",
  "hex",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.60.10+2040080526"
+version = "0.60.11+0257090526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/canary-bundle/CHANGELOG.md
+++ b/canary-bundle/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Canary Fleet — Changelog
 
+## [P1.13 follow-up] — MCP `view = "..."` regression test (2026-05-08)
+**Files:**
+- `canary-sql/libraries/handlers/p113-mcp-view.ts` (new) — `p113Probe` calls `Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", [])` and returns a TestResult envelope.
+- `canary-sql/app.toml` — new `[api.views.p113_probe_view]` (REST control) + `[api.views.mcp.tools.p113_view_probe]` with `view = "p113_probe_view"` (MCP experiment).
+- `run-tests.sh` — `p113-rest-control` and `p113-mcp-view-tool-call` assertions in the MCP block.
+
+**Description:** Operationalises the runtime fix that landed in #100 as a fleet-level regression test. Same V8 module is dispatched two ways: direct REST POST (control) and MCP `tools/call` with `view = "..."` (experiment). Both must return `passed: true`. If MCP regresses to throwing `CapabilityError: datasource 'canary-sqlite' not declared in view config`, the harness emits a `(CapabilityError — P1.13 regressed)` verdict so the failure is unambiguous.
+
+**Spec reference:** rivers-mcp-view-spec.md §13.2; CB upstream case-rivers-mcp-view-capability-propagation.md.
+
+**Resolution:** `riverpackage validate canary-bundle` → 0 errors. `canary-sqlite` chosen as the probe datasource so the test runs without external infra (no SKIP gate). +2 PASS in the canary score on a healthy build.
+
 ## [Decision] — Initial scaffolding
 **File:** manifest.toml, all app manifests
 **Description:** Created 6-app bundle structure per canary-fleet-spec.md

--- a/canary-bundle/canary-sql/app.toml
+++ b/canary-bundle/canary-sql/app.toml
@@ -872,6 +872,36 @@ dataview    = "pg_select_all"
 description = "Select all contacts from PostgreSQL"
 hints       = { read_only = true }
 
+# ── P1.13 — MCP `view = "..."` capability propagation ─────────
+# Regression probe for case-rivers-mcp-view-capability-propagation.md.
+# The CB-P1.13 fix in PR #100 wired datasources through MCP dispatch;
+# this canary exercise pins that contract end-to-end. Same V8 module
+# is exposed two ways:
+#   • REST control     /canary/sql/p113/probe   (handler reached the long way)
+#   • MCP experiment   tools/call name="p113_view_probe"
+# Both must return `passed:true`. If MCP regresses to throwing
+# `CapabilityError: datasource 'canary-sqlite' not declared in view config`,
+# the harness emits a `(P1.13 regressed)` verdict.
+# Spec: rivers-mcp-view-spec.md §13.2.
+
+[api.views.p113_probe_view]
+path      = "/canary/sql/p113/probe"
+view_type = "Rest"
+method    = "POST"
+auth      = "none"
+
+[api.views.p113_probe_view.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/p113-mcp-view.ts"
+entrypoint = "p113Probe"
+resources  = ["canary-sqlite"]
+
+[api.views.mcp.tools.p113_view_probe]
+view        = "p113_probe_view"
+description = "P1.13 — MCP view= dispatch into a codecomponent that calls Rivers.db.query"
+hints       = { read_only = true }
+
 # ── Scenario probe (CS1.4) ────────────────────────────────
 # SCENARIO-SQL-PROBE — validates the scenario-harness.ts envelope
 # shape end-to-end before CS2 Messaging scenarios are built on it.

--- a/canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts
+++ b/canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts
@@ -1,0 +1,71 @@
+// P1.13 — MCP `view = "..."` capability propagation regression probe.
+//
+// This handler is dispatched two ways during the canary run:
+//   1. Direct REST POST  → /canary/sql/p113/probe              (control)
+//   2. MCP tools/call    → name = "p113_view_probe"            (experiment)
+//
+// Both paths call the same V8 module + entrypoint. The probe asserts that
+// `Rivers.db.query("canary-sqlite", ...)` succeeds — which can only happen
+// if the dispatcher wired `canary-sqlite` into TASK_DS_CONFIGS for this
+// task. Before P1.13 was fixed, path #1 worked but path #2 threw
+// `CapabilityError: datasource 'canary-sqlite' not declared in view config`.
+//
+// Spec: rivers-mcp-view-spec.md §13.2; case-rivers-mcp-view-capability-propagation.md.
+
+function P113Result(test_id) {
+    this.test_id = test_id;
+    this.profile = "MCP";
+    this.spec_ref = "rivers-mcp-view-spec.md §13.2";
+    this.assertions = [];
+    this.error = null;
+    this.start = Date.now();
+}
+P113Result.prototype.assert = function(id, passed, detail) {
+    this.assertions.push({ id: id, passed: passed, detail: detail || undefined });
+};
+P113Result.prototype.finish = function() {
+    return {
+        test_id: this.test_id,
+        profile: this.profile,
+        spec_ref: this.spec_ref,
+        passed: this.assertions.every(function(a) { return a.passed; }),
+        assertions: this.assertions,
+        duration_ms: Date.now() - this.start,
+        error: this.error,
+    };
+};
+P113Result.prototype.fail = function(err) {
+    this.error = "" + err;
+    return {
+        test_id: this.test_id,
+        profile: this.profile,
+        spec_ref: this.spec_ref,
+        passed: false,
+        assertions: this.assertions,
+        duration_ms: Date.now() - this.start,
+        error: this.error,
+    };
+};
+
+// p113Probe — runs an in-bundle SELECT against canary-sqlite.
+//
+// The test_id is "P113-MCP-VIEW" so the canary harness can pin this single
+// regression. A successful return through MCP tools/call proves the inner
+// view's capability list propagated through dispatch_codecomponent_tool.
+function p113Probe(ctx) {
+    var t = new P113Result("P113-MCP-VIEW");
+    try {
+        var r = Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", []);
+        var rows = (r && r.rows) ? r.rows : [];
+        var answer = rows.length > 0 ? rows[0].answer : null;
+
+        t.assert("rivers-db-query-succeeded", rows.length === 1,
+            "expected 1 row, got " + rows.length);
+        t.assert("answer-equals-1", answer === 1 || answer === "1",
+            "expected answer=1, got " + JSON.stringify(answer));
+
+        return t.finish();
+    } catch (e) {
+        return t.fail(e);
+    }
+}

--- a/canary-bundle/run-tests.sh
+++ b/canary-bundle/run-tests.sh
@@ -559,6 +559,54 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# ── P1.13 — MCP `view = "..."` capability propagation ─────────
+# Regression for case-rivers-mcp-view-capability-propagation.md.
+# Both paths run the same handler (p113Probe). Both must return
+# `passed: true`. If `p113-mcp-view-tool-call` fails with a
+# CapabilityError, dispatch_codecomponent_tool has regressed — the
+# inner view's `[handler] resources` aren't being wired into the
+# task context for MCP-routed dispatches.
+
+# REST control — proves the handler works when reached the long way around.
+test_ep "p113-rest-control"        POST "$BASE/sql/canary/sql/p113/probe" '{}'
+
+# MCP experiment — the path that broke before P1.13. The MCP wrapper
+# nests the handler envelope as a JSON string inside content[0].text;
+# we verify the unwrapped envelope contains `passed: true` AND that
+# the answer row made it through (which proves Rivers.db.query
+# actually executed against canary-sqlite, i.e. the capability gate
+# accepted the datasource).
+P113_MCP=$(curl -skf -X POST "$MCP_EP" \
+  -H "Content-Type: application/json" \
+  -H "$MCP_SID_HEADER" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"p113_view_probe","arguments":{}}}' 2>/dev/null) || P113_MCP=""
+P113_VERDICT=$(echo "$P113_MCP" | python3 -c '
+import json, sys
+try:
+    rpc = json.load(sys.stdin)
+    text = rpc["result"]["content"][0]["text"]
+    inner = json.loads(text)
+    if inner.get("passed") is True and inner.get("test_id") == "P113-MCP-VIEW":
+        print("PASS")
+    elif "CapabilityError" in (inner.get("error") or ""):
+        print("REGRESSED")
+    else:
+        print("FAIL")
+except Exception:
+    print("ERR")
+' 2>/dev/null) || P113_VERDICT="ERR"
+case "$P113_VERDICT" in
+  PASS)
+    printf "  PASS %-40s\n" "p113-mcp-view-tool-call"
+    PASS=$((PASS+1)) ;;
+  REGRESSED)
+    printf "  FAIL %-40s (CapabilityError — P1.13 regressed)\n" "p113-mcp-view-tool-call"
+    FAIL=$((FAIL+1)) ;;
+  *)
+    printf "  FAIL %-40s\n" "p113-mcp-view-tool-call"
+    FAIL=$((FAIL+1)) ;;
+esac
+
 # ── Query Parameter Tests ────────────────────────────────────
 echo ""
 echo "  ── Query Parameters ──"

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,17 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-08 — P1.13 follow-up: close MCP HttpToken gap + canary regression coverage
+
+| File | Decision | Spec ref | Resolution |
+|------|----------|----------|------------|
+| `crates/riversd/src/mcp/dispatch.rs::dispatch_codecomponent_tool` | Capture `view_config.allow_outbound_http` alongside the codecomponent entrypoint inside the bundle scope block, then conditionally `builder.http(HttpToken)` before the existing `wire_datasources` call. | rivers-view-layer-spec.md §10.5 | Mirrors the REST pipeline's Codecomponent arm exactly. PR #100 wired datasources through this path but missed the HTTP capability — same shape of bug, just a different capability. |
+| `crates/riversd/src/task_enrichment.rs` (test module) | Added shared `p113_executor_with` / `p113_seed_builder` helpers + 3 branch-coverage tests (filesystem-direct, broker-token-and-config, empty-driver-skip). Did not touch the existing 2 tests in main. | rivers-mcp-view-spec.md §13.2 | Helpers reduce 60+ lines of boilerplate per test to a single line each; fail mode pinned at the exact assertion that would catch a regression. |
+| Canary scenario (handler + app.toml + run-tests.sh) | Operationalise the runtime fix as a fleet-level differential test: same V8 module dispatched via REST (control) and MCP `view = "..."` (experiment). MCP path explicitly distinguishes `CapabilityError` regression from generic failure so a future occurrence of this exact bug surfaces unambiguously in the canary log. | rivers-mcp-view-spec.md §13.2 | `canary-sqlite` chosen over postgres so no infra-gating SKIP; counts as +2 PASS on every healthy run. |
+| Workspace version | Patch bump `0.60.10 → 0.60.11`. | CLAUDE.md bump rules | Closing a documented-but-missing capability propagation on top of #100 + adding regression coverage. Patch, not minor. |
+
+---
+
 ## 2026-05-08 — Lift v1 chain prohibition: guard_view chains supported up to depth 5
 
 **Decision:** Plan H shipped a v1 chain prohibition (any `guard_view`

--- a/crates/riversd/src/mcp/dispatch.rs
+++ b/crates/riversd/src/mcp/dispatch.rs
@@ -437,7 +437,13 @@ async fn dispatch_codecomponent_tool(
     use rivers_runtime::view::HandlerConfig;
 
     // Locate the app in the loaded bundle by dv_namespace (entry_point slug).
-    let entrypoint = {
+    // P1.13 follow-up: capture `allow_outbound_http` alongside the entrypoint
+    // so the caller can wire `HttpToken` into the TaskContext exactly the way
+    // the REST pipeline does. Without this, an MCP-dispatched codecomponent
+    // whose backing view declared `allow_outbound_http = true` would still
+    // fail any `Rivers.http.*` call — same shape as the original P1.13 bug,
+    // just for the HTTP capability instead of datasources.
+    let (entrypoint, allow_outbound_http) = {
         let bundle = match ctx.loaded_bundle.as_ref() {
             Some(b) => b,
             None => return JsonRpcResponse::server_error(req.id.clone(), "no bundle loaded"),
@@ -461,11 +467,14 @@ async fn dispatch_codecomponent_tool(
             ),
         };
         match &view_config.handler {
-            HandlerConfig::Codecomponent { language, module, entrypoint, .. } => Entrypoint {
-                language: language.clone(),
-                module: module.clone(),
-                function: entrypoint.clone(),
-            },
+            HandlerConfig::Codecomponent { language, module, entrypoint, .. } => (
+                Entrypoint {
+                    language: language.clone(),
+                    module: module.clone(),
+                    function: entrypoint.clone(),
+                },
+                view_config.allow_outbound_http,
+            ),
             _ => return JsonRpcResponse::server_error(
                 req.id.clone(),
                 format!("view '{}' is not a codecomponent handler", view_name),
@@ -563,6 +572,16 @@ async fn dispatch_codecomponent_tool(
         .entrypoint(entrypoint)
         .args(args)
         .trace_id(trace_id.clone());
+    // P1.13 follow-up: propagate `allow_outbound_http` from the inner view.
+    // CB-P1.13 wired datasources but missed the HTTP token, leaving any view
+    // that opted into `Rivers.http.*` still broken on the MCP path. The
+    // REST pipeline's Codecomponent arm at `view_engine/pipeline.rs:273-275`
+    // sets the same flag the same way.
+    let builder = if allow_outbound_http {
+        builder.http(crate::process_pool::HttpToken)
+    } else {
+        builder
+    };
     // CB-P1.13: wire per-app datasource tokens/configs so codecomponent
     // handlers reached via MCP `view = "..."` dispatch can call
     // `Rivers.db.execute(...)` against their declared datasources — same

--- a/crates/riversd/src/task_enrichment.rs
+++ b/crates/riversd/src/task_enrichment.rs
@@ -402,4 +402,138 @@ mod tests {
         let task = builder.build().expect("task ctx builds");
         assert!(task.datasource_configs.is_empty());
     }
+
+    // ── P1.13 follow-up: branch coverage for `wire_datasources` ─────────────
+    //
+    // The existing tests above cover the SQL/cross-namespace and no-executor
+    // branches. The helper has three more branches the original CB-P1.13
+    // patch didn't pin. Each one is a path that the V8 worker reads — if any
+    // regresses, an MCP-dispatched handler would silently lose access to a
+    // capability that worked under REST. These tests exist to fail loudly
+    // before that asymmetry slips back in.
+
+    /// Helper: build a single-app executor with a parameterised driver. Used
+    /// to keep each branch test focused on one driver class without the
+    /// boilerplate of constructing the executor + ConnectionParams inline.
+    fn p113_executor_with(
+        ds_key: &str,
+        driver: &str,
+        database: &str,
+    ) -> Arc<DataViewExecutor> {
+        use std::collections::HashMap;
+        use rivers_runtime::rivers_driver_sdk::ConnectionParams;
+
+        let mut opts: HashMap<String, String> = HashMap::new();
+        opts.insert("driver".into(), driver.to_string());
+        let mut params: HashMap<String, ConnectionParams> = HashMap::new();
+        params.insert(
+            ds_key.to_string(),
+            ConnectionParams {
+                host: "localhost".into(),
+                port: 0,
+                database: database.to_string(),
+                username: String::new(),
+                password: String::new(),
+                options: opts,
+            },
+        );
+        Arc::new(DataViewExecutor::new(
+            DataViewRegistry::new(),
+            Arc::new(DriverFactory::new()),
+            Arc::new(params),
+            Arc::new(NoopDataViewCache),
+        ))
+    }
+
+    fn p113_seed_builder() -> TaskContextBuilder {
+        TaskContextBuilder::new()
+            .entrypoint(Entrypoint {
+                module: "handlers/h.js".into(),
+                function: "handle".into(),
+                language: "javascript".into(),
+            })
+            .args(serde_json::json!({}))
+            .trace_id("p113-branch".into())
+            .app_id("myapp".into())
+    }
+
+    /// Filesystem driver: lands as a `DatasourceToken::Direct` token, NOT in
+    /// `datasource_configs`. The codecomponent reaches it through the
+    /// in-process direct-dispatch path, not the DriverFactory connect cycle.
+    #[test]
+    fn wire_datasources_filesystem_yields_direct_token_only() {
+        let executor = p113_executor_with("myapp:files", "filesystem", "/tmp/probe-data");
+        let builder = wire_datasources(p113_seed_builder(), Some(executor.as_ref()), "myapp");
+        let task = builder.build().expect("task ctx builds");
+
+        assert!(
+            task.datasources.contains_key("files"),
+            "filesystem ds must be wired as a DatasourceToken (got keys {:?})",
+            task.datasources.keys().collect::<Vec<_>>(),
+        );
+        assert!(
+            !task.datasource_configs.contains_key("files"),
+            "filesystem must NOT populate datasource_configs (the worker uses \
+             the direct token path, not DriverFactory)",
+        );
+    }
+
+    /// Broker driver: gets BOTH a `DatasourceToken::Broker` AND a
+    /// `ResolvedDatasource` config (per BR-2026-04-23 — the worker uses the
+    /// token to route and the config to lazy-build a BrokerProducer).
+    #[test]
+    fn wire_datasources_broker_yields_token_and_config() {
+        let executor = p113_executor_with("myapp:events", "kafka", "events-topic");
+        let builder = wire_datasources(p113_seed_builder(), Some(executor.as_ref()), "myapp");
+        let task = builder.build().expect("task ctx builds");
+
+        assert!(
+            task.datasources.contains_key("events"),
+            "broker ds must produce a DatasourceToken so the worker can route writes",
+        );
+        let resolved = task.datasource_configs.get("events").expect(
+            "broker ds must ALSO populate datasource_configs so the worker can \
+             lazy-build a producer with the right ConnectionParams",
+        );
+        assert_eq!(resolved.driver_name, "kafka");
+    }
+
+    /// A datasource entry whose `options.driver` is absent or empty must be
+    /// silently skipped — no token, no config. Defends against a partial
+    /// resources.toml ever inflating the task scope.
+    #[test]
+    fn wire_datasources_skips_entries_with_empty_driver() {
+        use std::collections::HashMap;
+        use rivers_runtime::rivers_driver_sdk::ConnectionParams;
+
+        // Build params manually so we can omit the `driver` option entirely.
+        let mut params: HashMap<String, ConnectionParams> = HashMap::new();
+        params.insert(
+            "myapp:no_driver".to_string(),
+            ConnectionParams {
+                host: String::new(),
+                port: 0,
+                database: String::new(),
+                username: String::new(),
+                password: String::new(),
+                options: HashMap::new(),
+            },
+        );
+        let executor = Arc::new(DataViewExecutor::new(
+            DataViewRegistry::new(),
+            Arc::new(DriverFactory::new()),
+            Arc::new(params),
+            Arc::new(NoopDataViewCache),
+        ));
+
+        let builder = wire_datasources(p113_seed_builder(), Some(executor.as_ref()), "myapp");
+        let task = builder.build().expect("task ctx builds");
+
+        assert!(
+            task.datasources.is_empty() && task.datasource_configs.is_empty(),
+            "missing/empty driver must skip the entry entirely; got tokens={:?}, configs={:?}",
+            task.datasources.keys().collect::<Vec<_>>(),
+            task.datasource_configs.keys().collect::<Vec<_>>(),
+        );
+    }
 }

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2026-05-08 — P1.13 follow-up: HttpToken + canary regression + branch-coverage tests (v0.60.11)
+
+PR #100 shipped the runtime fix for case-rivers-mcp-view-capability-propagation.md
+(CB-P1.13) by wiring datasources through `dispatch_codecomponent_tool` via
+`task_enrichment::wire_datasources`. This follow-up closes three gaps it left:
+
+1. The MCP path still didn't propagate `allow_outbound_http`, so a view opting
+   into `Rivers.http.*` was still broken when reached via MCP.
+2. No fleet-level regression test — only unit coverage.
+3. `wire_datasources` had unit tests for the SQL/cross-namespace branches but
+   not for filesystem, broker, or empty-driver-skip.
+
+| File | What changed | Spec ref | Resolution |
+|------|-------------|----------|------------|
+| `crates/riversd/src/mcp/dispatch.rs` | `dispatch_codecomponent_tool` now captures `allow_outbound_http` from the inner view alongside the entrypoint, and attaches `crate::process_pool::HttpToken` to the builder when set. Mirrors REST pipeline at `view_engine/pipeline.rs:273-275`. | rivers-view-layer-spec.md §10.5; rivers-mcp-view-spec.md §13.2 | 3-line addition to the existing CB-P1.13 wiring block. No structural change to the dispatch flow. |
+| `crates/riversd/src/task_enrichment.rs` | Added 3 branch-coverage tests for `wire_datasources`: filesystem driver → `DatasourceToken::Direct` only (no config); broker driver → both token AND config (per BR-2026-04-23); empty/missing driver → silently skipped. Plus shared `p113_executor_with` / `p113_seed_builder` helpers to keep each test focused. | rivers-mcp-view-spec.md §13.2 | All 3 tests green; combined with main's existing 2 wire_datasources tests, every branch is now pinned. |
+| `canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts` (new) | New canary handler `p113Probe` — calls `Rivers.db.query("canary-sqlite", "SELECT 1 AS answer", [])` and shapes a TestResult envelope with `test_id="P113-MCP-VIEW"`. Same module reached via two routes (REST control + MCP `view = "..."`). | rivers-mcp-view-spec.md §13.2 | Uses `canary-sqlite` (no external infra) so the test runs unconditionally. |
+| `canary-bundle/canary-sql/app.toml` | Added `[api.views.p113_probe_view]` (REST/POST/none, codecomponent → `p113Probe`, `resources = ["canary-sqlite"]`) and `[api.views.mcp.tools.p113_view_probe]` with `view = "p113_probe_view"`. | rivers-mcp-view-spec.md §13.2 | `riverpackage validate canary-bundle` → 0 errors. |
+| `canary-bundle/run-tests.sh` | Added two MCP-block assertions: `p113-rest-control` (REST POST → expect `passed:true`) and `p113-mcp-view-tool-call` (MCP `tools/call` → unwrap `content[0].text`, parse inner envelope, assert `passed:true && test_id=="P113-MCP-VIEW"`). MCP path explicitly distinguishes `CapabilityError` regression with a `REGRESSED` verdict so a future failure of this exact bug surfaces unambiguously. | rivers-mcp-view-spec.md §13.2 | Differential pair (same handler, two transports). +2 PASS on healthy canary. |
+| `Cargo.toml` (workspace) | Version bump 0.60.10 → 0.60.11 + new build stamp | Bump rules (CLAUDE.md) | Patch — closes a documented-but-missing API-coverage gap on top of #100. |
+
 ## 2026-05-08 — Lift v1 chain prohibition for guard_view
 
 `guard_view` chains are now allowed up to `MAX_GUARD_CHAIN_DEPTH`


### PR DESCRIPTION
## Summary

Follow-up to #100 (CB-P1.13). Closes three gaps that fix left:

1. **HttpToken propagation gap** — #100 wired datasources through MCP `view = "..."` dispatch but missed `allow_outbound_http`. A view opting into `Rivers.http.*` was still broken when reached via MCP — same shape of bug as P1.13, different capability.
2. **No fleet-level regression** — only unit coverage existed.
3. **Branch coverage** — `wire_datasources` had tests for the SQL/cross-namespace paths but not filesystem, broker, or empty-driver-skip.

Builds on #100 (which is the runtime fix); does not replace it.

## What changed

| Layer | File | Change |
|---|---|---|
| Runtime | `crates/riversd/src/mcp/dispatch.rs` | `dispatch_codecomponent_tool` captures `allow_outbound_http` from the inner view alongside the entrypoint, then attaches `HttpToken` to the builder when set. Mirrors REST at `view_engine/pipeline.rs:273-275`. 3-line addition to the existing CB-P1.13 wiring block. |
| Unit tests | `crates/riversd/src/task_enrichment.rs` | 3 new branch-coverage tests for `wire_datasources`: filesystem → `DatasourceToken::Direct` only; broker → both token AND config (per BR-2026-04-23); empty/missing driver → silently skipped. Plus shared `p113_executor_with` / `p113_seed_builder` helpers. |
| Canary | `canary-bundle/canary-sql/libraries/handlers/p113-mcp-view.ts` (new) | `p113Probe` calls `Rivers.db.query(\"canary-sqlite\", \"SELECT 1 AS answer\", [])` and returns a TestResult envelope. |
| Canary | `canary-bundle/canary-sql/app.toml` | New REST view `p113_probe_view` (control) + MCP tool `p113_view_probe` with `view = \"p113_probe_view\"` (experiment). |
| Canary | `canary-bundle/run-tests.sh` | `p113-rest-control` + `p113-mcp-view-tool-call` MCP-block assertions. MCP path emits `(P1.13 regressed)` on `CapabilityError` so a future regression of this exact bug surfaces unambiguously. |
| Version | `Cargo.toml` | `0.60.10 → 0.60.11+0257090526` (patch — closing a documented-but-missing capability propagation on top of #100). |
| Docs | `todo/changelog.md`, `changedecisionlog.md`, `canary-bundle/CHANGELOG.md` | Decision log + changelog entries. |

## Test plan

- [x] `cargo test -p riversd --lib task_enrichment` → **7/7 pass** (4 pre-existing + 3 new branch-coverage)
- [x] `cargo check -p riversd` → clean
- [x] `riverpackage validate canary-bundle` → 0 errors
- [x] `bash -n canary-bundle/run-tests.sh` → syntax OK
- [ ] Live canary run on a deployed instance — `p113-rest-control` + `p113-mcp-view-tool-call` PASS

## Differential coverage

The canary scenario hits the **same V8 module** via two transports:

```
            ┌─ REST POST  /canary/sql/p113/probe   →  p113Probe(ctx)
canary-sql ─┤
            └─ MCP tools/call name=p113_view_probe →  p113Probe(ctx)
```

Both must return identical envelopes. If MCP regresses to `CapabilityError`, the harness output reads:
```
  FAIL p113-mcp-view-tool-call                (CapabilityError — P1.13 regressed)
```

This is the operational counterpart to the unit tests in `task_enrichment.rs` — three layers of defence:

1. Unit tests pin the wiring contract at `cargo test` time.
2. Bundle validation catches misconfiguration at deploy time.
3. Canary differential pair catches a runtime regression at live-test time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)