### PR TITLE
fix(cron): propagate handler resources as task capabilities (v0.61.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-deploy"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "rcgen",
  "rivers-core-config",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "riverpackage"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "rivers-core-config",
  "rivers-driver-sdk",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5701,7 +5701,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-core-config"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-driver-sdk"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-drivers-builtin"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-memcached",
  "async-trait",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-sdk"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-v8"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "base64 0.22.1",
  "bcrypt",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-engine-wasm"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "rivers-engine-sdk",
  "serde_json",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "clap",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-keystore-engine"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "chrono",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-lockbox-engine"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "chrono",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-cassandra"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-couchdb"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-elasticsearch"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-exec"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-trait",
  "hex",
@@ -5915,7 +5915,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-influxdb"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-kafka"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-ldap"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-mongodb"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-nats"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-nats",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-neo4j"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-rabbitmq"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-plugin-redis-streams"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "age",
  "async-trait",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-runtime"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-trait",
  "cron",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "rivers-storage-backends"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-trait",
  "redis",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "riversctl"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "riversd"
-version = "0.61.0+0008110526"
+version = "0.61.1+0135110526"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.61.0+0017110526"
+version = "0.61.1+0139110526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/changedecisionlog.md
+++ b/changedecisionlog.md
@@ -4,6 +4,35 @@ Per CLAUDE.md Workflow rule 5: every decision during implementation is logged he
 
 ---
 
+## 2026-05-10 — Cron view capability propagation (v0.61.0 → v0.61.1)
+
+CB filed `cb-rivers-cron-capability-bug` against v0.61.0 — Cron handlers
+fail with `CapabilityError: datasource '<name>' not declared in view
+config` at every tick, even when the validator reports the resource as
+resolved. Same exact shape as the MCP-view bug fixed in v0.60.12
+(P1.13): the dispatcher builds a `TaskContextBuilder` and forgets to
+call `wire_datasources` before `enrich`. Track 3 of the v0.61.0 sprint
+shipped Cron without a datasource-using test scenario, so the omission
+slid past CI.
+
+| File | Decision | Spec ref | Resolution |
+|------|----------|----------|------------|
+| `crates/riversd/src/task_enrichment.rs` | Add a new entry point — `wire_datasources_from_shared(builder, dv_namespace)` — instead of plumbing `DataViewExecutor` through `CronScheduler::start`. Cron loops live on detached `tokio::task`s for the bundle's lifetime; they have no `AppContext` handle and no good way to refresh one on reload. The executor is already snapshotted into `SHARED_TASK_CAPABILITIES` at every bundle load/reload (line 996 of `bundle_loader/load.rs`), so reading from there is correct *and* hot-reload-safe. | `rivers-cron-view-spec.md` §3.1; mirrors REST/MCP datasource wiring | Reuses the existing `wire_datasources(builder, executor, dv_namespace)` body — the new function is a thin shim, no duplicated logic. |
+| `crates/riversd/src/cron/mod.rs::CronViewSpec` | Add `entry_point: String` field alongside the existing `app_id: String`. Keep `app_id` (manifest UUID) for storage dedupe and metric labels — those have been wired against the UUID since v0.61.0 and changing them would break the dedupe key shape. The new `entry_point` is what gets passed to `enrich` and `wire_datasources_from_shared`. | RT-CTX-APP-ID parity (2026-05-05 canary sprint correction; mcp/dispatch.rs line 597-604) | Surgical addition — no rename, no behavior change for dedupe/metrics. |
+| `crates/riversd/src/cron/mod.rs::dispatch_tick` | Call `wire_datasources_from_shared(builder, entry_point)` after the storage wiring and before `enrich`. Then pass `entry_point` (NOT `app_id`) to `enrich` for parity with mcp/dispatch.rs line 604. | spec §4 (tick lifecycle) | One-line shim per logical step. Three `spec.entry_point.clone()` sites in `run_cron_loop` (Queue/Skip/Allow) match the existing `spec.app_id.clone()` pattern. |
+| Test coverage | Add two unit tests in `task_enrichment.rs::tests` that exercise `wire_datasources_from_shared` directly — one with a populated snapshot, one with the default (empty) snapshot. Did NOT add a Cron-integration test that drives V8: the dispatch wiring is now isomorphic with REST/MCP, and the existing direct-dispatch e2e test in `sprint_2026_05_09_e2e.rs::track3_direct_dispatch_handler_writes_to_store` already proves the V8 path from a `TaskContextBuilder`. The bug was strictly in the builder construction. | `rivers-cron-view-spec.md` §13 | Two tests, no V8 boot, runs in <10ms total. |
+| Workspace version | Patch bump `0.61.0 → 0.61.1`. | CLAUDE.md bump rules | Filling a documented-but-missing capability path (validator passes, runtime errors). Patch, not minor — the Cron primitive itself shipped in 0.61.0; this fixes a propagation gap. |
+
+**Reuse-vs-new judgement:** the `wire_datasources` function is the
+existing pattern. Reusing it via a small `_from_shared` shim was correct
+— rewriting it to walk SHARED_TASK_CAPABILITIES internally would have
+broken the explicit-executor callers (REST/MCP/SSE/WS) that still need
+to pass an executor they hold a reference to. The shim adds one tested
+branch (shared-state read) to the existing four (sql/filesystem/broker/
+empty-driver).
+
+---
+
 ## 2026-05-08 — P1.13 follow-up: close MCP HttpToken gap + canary regression coverage
 
 | File | Decision | Spec ref | Resolution |

--- a/crates/riversd/src/cron/mod.rs
+++ b/crates/riversd/src/cron/mod.rs
@@ -69,9 +69,13 @@ impl OverlapPolicy {
 /// last-mile defensive check).
 #[derive(Debug, Clone)]
 pub struct CronViewSpec {
-    /// App that owns this view (used for the StorageEngine dedupe key,
-    /// per-app log routing, and capability namespace).
+    /// App that owns this view (manifest UUID — used for the StorageEngine
+    /// dedupe key and metric labels). NOT the capability namespace key.
     pub app_id: String,
+    /// Entry-point slug (`manifest.entry_point` or `manifest.app_name`) —
+    /// used as `dv_namespace` for datasource wiring and keystore lookup.
+    /// Mirrors how REST/MCP/SSE dispatchers resolve per-app capabilities.
+    pub entry_point: String,
     /// View name as declared in `[api.views.<name>]`.
     pub view_name: String,
     /// Resolved schedule.
@@ -89,6 +93,7 @@ impl CronViewSpec {
     /// is not actually a Cron view.
     pub fn from_view_config(
         app_id: &str,
+        entry_point: &str,
         view_name: &str,
         cfg: &ApiViewConfig,
     ) -> Result<Option<Self>, CronSpecError> {
@@ -115,6 +120,7 @@ impl CronViewSpec {
 
         Ok(Some(CronViewSpec {
             app_id: app_id.to_string(),
+            entry_point: entry_point.to_string(),
             view_name: view_name.to_string(),
             schedule,
             overlap: OverlapPolicy::from_str_or_default(cfg.overlap_policy.as_deref()),
@@ -253,11 +259,16 @@ pub fn collect_cron_specs(bundle: &rivers_runtime::LoadedBundle) -> Vec<CronView
     let mut out = Vec::new();
     for app in &bundle.apps {
         let app_id = &app.manifest.app_id;
+        let entry_point = app
+            .manifest
+            .entry_point
+            .as_deref()
+            .unwrap_or(&app.manifest.app_name);
         for (view_name, view_cfg) in &app.config.api.views {
             if view_cfg.view_type != "Cron" {
                 continue;
             }
-            match CronViewSpec::from_view_config(app_id, view_name, view_cfg) {
+            match CronViewSpec::from_view_config(app_id, entry_point, view_name, view_cfg) {
                 Ok(Some(spec)) => out.push(spec),
                 Ok(None) => {} // not a Cron view (shouldn't happen given the filter above)
                 Err(e) => {
@@ -378,11 +389,12 @@ async fn run_cron_loop(
         let pool = pool.clone();
         let storage = storage.clone();
         let app_id = spec.app_id.clone();
+        let entry_point = spec.entry_point.clone();
         let view = spec.view_name.clone();
         let entry = spec.entrypoint.clone();
         tokio::spawn(async move {
             while let Some(job) = rx.recv().await {
-                dispatch_tick(&pool, storage.clone(), &app_id, &view, &entry, job).await;
+                dispatch_tick(&pool, storage.clone(), &app_id, &entry_point, &view, &entry, job).await;
             }
         });
         Some(tx)
@@ -499,10 +511,11 @@ async fn run_cron_loop(
                 let pool = pool.clone();
                 let storage = storage.clone();
                 let app_id = spec.app_id.clone();
+                let entry_point = spec.entry_point.clone();
                 let view = spec.view_name.clone();
                 let entry = spec.entrypoint.clone();
                 tokio::spawn(async move {
-                    dispatch_tick(&pool, storage, &app_id, &view, &entry, job).await;
+                    dispatch_tick(&pool, storage, &app_id, &entry_point, &view, &entry, job).await;
                 });
             }
             OverlapPolicy::Queue => {
@@ -524,10 +537,11 @@ async fn run_cron_loop(
                 let pool = pool.clone();
                 let storage = storage.clone();
                 let app_id = spec.app_id.clone();
+                let entry_point = spec.entry_point.clone();
                 let view = spec.view_name.clone();
                 let entry = spec.entrypoint.clone();
                 tokio::spawn(async move {
-                    dispatch_tick(&pool, storage, &app_id, &view, &entry, job).await;
+                    dispatch_tick(&pool, storage, &app_id, &entry_point, &view, &entry, job).await;
                 });
             }
         }
@@ -554,6 +568,7 @@ async fn dispatch_tick(
     pool: &ProcessPoolManager,
     storage: Arc<dyn StorageEngine>,
     app_id: &str,
+    entry_point: &str,
     view_name: &str,
     entrypoint: &Entrypoint,
     job: TickJob,
@@ -586,7 +601,15 @@ async fn dispatch_tick(
         .args(args)
         .trace_id(trace_id)
         .storage(storage);
-    let builder = crate::task_enrichment::enrich(builder, app_id, TaskKind::Rest);
+    // CB-cron-cap-fix: wire per-app datasource tokens/configs so handlers
+    // reached via Cron dispatch can call `Rivers.db.query(...)` against
+    // their declared datasources — same capability shape REST/MCP use.
+    // Same omission MCP carried before v0.60.12 (P1.13).
+    let builder = crate::task_enrichment::wire_datasources_from_shared(builder, entry_point);
+    // RT-CTX-APP-ID parity: enrich keys on the entry-point slug (used for
+    // keystore lookup and surfaced as `ctx.app_id` to handlers), not the
+    // manifest UUID. Mirrors mcp/dispatch.rs and view_engine/pipeline.rs.
+    let builder = crate::task_enrichment::enrich(builder, entry_point, TaskKind::Rest);
 
     let result = match builder.build() {
         Ok(ctx) => pool.dispatch("default", ctx).await,
@@ -800,7 +823,7 @@ mod tests {
         // Build a Rest view config — should yield Ok(None).
         // We only need view_type and handler set; default rest of the fields.
         let cfg = make_rest_view_config();
-        let spec = CronViewSpec::from_view_config("app1", "v", &cfg).unwrap();
+        let spec = CronViewSpec::from_view_config("app1", "app1", "v", &cfg).unwrap();
         assert!(spec.is_none());
     }
 
@@ -811,7 +834,7 @@ mod tests {
         cfg.handler = rivers_runtime::view::HandlerConfig::Dataview {
             dataview: "irrelevant".to_string(),
         };
-        let err = CronViewSpec::from_view_config("app1", "v", &cfg).unwrap_err();
+        let err = CronViewSpec::from_view_config("app1", "app1", "v", &cfg).unwrap_err();
         assert!(matches!(err, CronSpecError::HandlerNotCodecomponent));
     }
 
@@ -820,7 +843,7 @@ mod tests {
         let mut cfg = make_cron_view_config_skeleton();
         cfg.schedule = None;
         cfg.interval_seconds = None;
-        let err = CronViewSpec::from_view_config("app1", "v", &cfg).unwrap_err();
+        let err = CronViewSpec::from_view_config("app1", "app1", "v", &cfg).unwrap_err();
         assert!(matches!(err, CronSpecError::NoSchedule));
     }
 
@@ -829,14 +852,14 @@ mod tests {
         let mut cfg = make_cron_view_config_skeleton();
         cfg.schedule = Some("0 */5 * * * *".to_string());
         cfg.interval_seconds = Some(300);
-        let err = CronViewSpec::from_view_config("app1", "v", &cfg).unwrap_err();
+        let err = CronViewSpec::from_view_config("app1", "app1", "v", &cfg).unwrap_err();
         assert!(matches!(err, CronSpecError::ScheduleAndIntervalBothSet));
     }
 
     #[test]
     fn cron_view_spec_parses_canonical() {
         let cfg = make_cron_view_config(NextTick::Interval(std::time::Duration::from_secs(300)));
-        let spec = CronViewSpec::from_view_config("app1", "v", &cfg)
+        let spec = CronViewSpec::from_view_config("app1", "app1", "v", &cfg)
             .unwrap()
             .unwrap();
         assert_eq!(spec.app_id, "app1");

--- a/crates/riversd/src/task_enrichment.rs
+++ b/crates/riversd/src/task_enrichment.rs
@@ -131,6 +131,31 @@ pub fn wire_datasources(
     builder
 }
 
+/// Wire per-app datasource tokens and configs using the executor cached in
+/// `SHARED_TASK_CAPABILITIES`.
+///
+/// Used by dispatch paths that have no direct handle on `AppContext` (Cron
+/// loops live on their own `tokio::task`s spawned at bundle load time). For
+/// REST/MCP/SSE/WS, callers still pass the executor explicitly via
+/// [`wire_datasources`].
+///
+/// CB-cron-cap-fix (2026-05-10): introduced so the Cron tick dispatcher can
+/// propagate `[api.views.X.handler] resources` into the task capability set
+/// the same way REST/MCP do. Without this, `Rivers.db.query` from inside a
+/// Cron handler fails with `CapabilityError: datasource '<name>' not
+/// declared in view config`.
+pub fn wire_datasources_from_shared(
+    builder: TaskContextBuilder,
+    dv_namespace: &str,
+) -> TaskContextBuilder {
+    let executor = SHARED_TASK_CAPABILITIES
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .dataview_executor
+        .clone();
+    wire_datasources(builder, executor.as_deref(), dv_namespace)
+}
+
 /// Enrich a TaskContextBuilder with all capabilities available from shared state.
 ///
 /// New capabilities wired here automatically become available to every dispatch site.
@@ -535,5 +560,45 @@ mod tests {
             task.datasources.keys().collect::<Vec<_>>(),
             task.datasource_configs.keys().collect::<Vec<_>>(),
         );
+    }
+
+    /// CB-cron-cap-fix (2026-05-10): `wire_datasources_from_shared` reads
+    /// the executor stashed in `SHARED_TASK_CAPABILITIES` and wires
+    /// per-app datasources. Cron dispatch uses this because it has no
+    /// direct `AppContext` handle — without it, every Cron handler that
+    /// calls `Rivers.db.*` fails with CapabilityError.
+    #[test]
+    fn wire_datasources_from_shared_uses_snapshot_executor() {
+        let executor = p113_executor_with("myapp:cb_db", "sqlite", "/tmp/cb.db");
+
+        let previous = replace_shared_capabilities(SharedTaskCapabilities {
+            dataview_executor: Some(executor),
+            ..SharedTaskCapabilities::default()
+        });
+
+        let task = wire_datasources_from_shared(p113_seed_builder(), "myapp")
+            .build()
+            .expect("task ctx builds");
+
+        assert!(
+            task.datasource_configs.contains_key("cb_db"),
+            "shared-state path must wire app-scoped datasources just like the explicit path"
+        );
+
+        replace_shared_capabilities(previous);
+    }
+
+    /// No executor in shared state → no-op (must not panic). Mirrors the
+    /// `None` branch of `wire_datasources`.
+    #[test]
+    fn wire_datasources_from_shared_is_noop_when_unset() {
+        let previous = replace_shared_capabilities(SharedTaskCapabilities::default());
+
+        let task = wire_datasources_from_shared(p113_seed_builder(), "myapp")
+            .build()
+            .expect("task ctx builds");
+        assert!(task.datasource_configs.is_empty());
+
+        replace_shared_capabilities(previous);
     }
 }

--- a/crates/riversd/tests/sprint_2026_05_09_e2e.rs
+++ b/crates/riversd/tests/sprint_2026_05_09_e2e.rs
@@ -180,7 +180,7 @@ resources  = []
 "#,
     );
 
-    let spec = CronViewSpec::from_view_config("app1", "recompute", &cfg)
+    let spec = CronViewSpec::from_view_config("app1", "app1", "recompute", &cfg)
         .expect("spec build")
         .expect("spec is Some for Cron view");
     assert_eq!(spec.app_id, "app1");
@@ -207,7 +207,7 @@ entrypoint = "t"
 resources  = []
 "#,
     );
-    let spec = CronViewSpec::from_view_config("a", "v", &cfg).unwrap().unwrap();
+    let spec = CronViewSpec::from_view_config("a", "a", "v", &cfg).unwrap().unwrap();
     assert_eq!(spec.entrypoint.language, "javascript");
 }
 
@@ -321,7 +321,7 @@ async fn track3_cron_handler_runs_and_writes_to_store() {
         entrypoint: "tick".to_string(),
         resources: vec![],
     };
-    let spec = CronViewSpec::from_view_config("e2e_app", "tick_view", &cfg)
+    let spec = CronViewSpec::from_view_config("e2e_app", "e2e_app", "tick_view", &cfg)
         .unwrap()
         .unwrap();
 
@@ -510,7 +510,7 @@ fn build_cron_spec_with_interval(
         entrypoint: "tick".to_string(),
         resources: vec![],
     };
-    CronViewSpec::from_view_config(app_id, view_name, &cfg)
+    CronViewSpec::from_view_config(app_id, app_id, view_name, &cfg)
         .expect("spec build ok")
         .expect("spec is Some")
 }

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2026-05-10 — Cron view: propagate handler `resources` as task capabilities (v0.61.1)
+
+CB filed `cb-rivers-cron-capability-bug` — a Cron view with
+`[api.views.X.handler] resources = ["my_db"]` passes the validator but
+the handler errors at tick time with `CapabilityError: datasource
+'my_db' not declared in view config`. Same `resources = [...]`
+declaration works fine for REST and MCP-view handlers. Root cause:
+v0.61.0 Cron dispatcher built the `TaskContextBuilder` without calling
+`wire_datasources` — the exact same shape of bug MCP carried before
+v0.60.12 (P1.13). It also passed the manifest UUID to `enrich` where
+every other dispatch path passes the entry-point slug (RT-CTX-APP-ID
+parity).
+
+| File | Change | Spec ref | Resolution |
+|------|--------|----------|------------|
+| `crates/riversd/src/task_enrichment.rs` | Added `wire_datasources_from_shared(builder, dv_namespace)` — reads the snapshotted executor from `SHARED_TASK_CAPABILITIES` and calls `wire_datasources`. Cron loops live on their own `tokio::task`s without an `AppContext` handle, so they need a way to wire datasources from shared state. | `rivers-cron-view-spec.md` §3.1 | New helper + two unit tests covering both the populated and empty branches. |
+| `crates/riversd/src/cron/mod.rs` | `CronViewSpec` gained an `entry_point: String` field (entry-point slug used as `dv_namespace`). `collect_cron_specs` resolves it via `manifest.entry_point.as_deref().unwrap_or(&manifest.app_name)` — same pattern bundle_diff/wire use. `from_view_config` takes it as a new `&str` parameter. | spec §3.1 | Signature change cascades into existing test helpers; the second `&str` arg is `entry_point`. |
+| `crates/riversd/src/cron/mod.rs` | `dispatch_tick` takes `entry_point: &str`. It now calls `wire_datasources_from_shared(builder, entry_point)` and passes `entry_point` (not the manifest UUID) to `enrich`. Mirrors `mcp/dispatch.rs:585-604` exactly. | spec §4 (tick lifecycle), MCP analogous fix | Both `run_cron_loop` spawn sites (Skip/Allow) plus the Queue consumer task clone `spec.entry_point` alongside `spec.app_id`. |
+| `crates/riversd/tests/sprint_2026_05_09_e2e.rs` | Updated four `from_view_config(...)` test call sites for the new 4-arg signature. | — | Tests still compile-clean; behavior unchanged for callers that don't use datasources. |
+| `Cargo.toml` (workspace) | Bumped 0.61.0 → 0.61.1 (patch — code fix closing a documented-but-missing capability path, per CLAUDE.md versioning rules). | CLAUDE.md versioning | `just bump-patch`. |
+
+**Backstop test:** `wire_datasources_from_shared_uses_snapshot_executor`
+in `task_enrichment.rs` exercises the exact code path Cron dispatch
+takes — seeds `SHARED_TASK_CAPABILITIES` with a sqlite-driver-flavored
+executor, calls the helper, and asserts the resulting task carries
+`datasource_configs["cb_db"]`. If the helper ever silently regresses to
+ignoring the shared snapshot, this test fails before any handler tick
+fires.
+
+**End-to-end repro:** CB's `cb-rivers-cron-capability-bug/run-probe.sh`
+should now produce REST-path PASS + Cron-path PASS.
+
 ## 2026-05-10 — Sprint 2026-05-09 Track 3 follow-ups: graceful shutdown, W011 warning, hard-fail on missing storage
 
 Three small gaps in the initial Track 3 ship, addressed before merge:


### PR DESCRIPTION
## Summary

- Fix v0.61.0 Cron capability-propagation bug — `[api.views.X.handler] resources = ["my_db"]` passed the validator but Cron handlers errored at every tick with `CapabilityError: datasource 'my_db' not declared in view config`. Same shape as the MCP P1.13 fix (v0.60.12) — Track 3 shipped Cron without a datasource-using test, so the omission slid past CI.
- Add `wire_datasources_from_shared(builder, dv_namespace)` in `task_enrichment` for dispatch paths without an `AppContext` handle (Cron loops live on detached `tokio::task`s). Reads the executor from the already-snapshotted `SHARED_TASK_CAPABILITIES`.
- `CronViewSpec` gains an `entry_point` field; `dispatch_tick` calls the new helper and passes the entry-point slug (not the manifest UUID) to `enrich` — RT-CTX-APP-ID parity with `mcp/dispatch.rs:585-604`.

## Root cause

`crates/riversd/src/cron/mod.rs::dispatch_tick` built a `TaskContextBuilder` and went straight to `enrich`, skipping `wire_datasources` entirely. The handler dispatched fine, but `TASK_DS_CONFIGS` was empty in the V8 worker — so `Rivers.db.query('probe_db', ...)` threw immediately. Same shape MCP carried before #112.

## Reproducer

CB filed `cb-rivers-cron-capability-bug.zip` (in `/Users/pcastone/Projects/cb/docs/rivers-upstream/`). The bundle declares two views with identical `resources = ["probe_db"]` — `rest_read` returns 200, `cron_tick` logs `CapabilityError` every minute. After this fix both pass.

## Test plan

- [x] `cargo test -p riversd --lib task_enrichment::` — 9 passed (2 new tests cover the populated + empty shared-snapshot branches)
- [x] `cargo test -p riversd --lib cron::` — 12 passed (existing cron tests + 4-arg `from_view_config` signature update)
- [x] `cargo build -p riversd` — clean
- [x] `cargo test -p riversd --tests --no-run` — all integration test binaries link
- [ ] Run CB's `cb-rivers-cron-capability-bug/run-probe.sh` against `v0.61.1` to confirm REST-path PASS + Cron-path PASS

## Version

`just bump-patch`: 0.61.0 → 0.61.1. Patch bump per CLAUDE.md — filling a documented-but-missing capability path (validator passes, runtime errors); the Cron primitive itself shipped in 0.61.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)