### PR TITLE
feat(otlp): Track O1 — view_type = "OTLP" validator + spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.61.1+0139110526"
+version = "0.61.1+1721110526"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/rivers-runtime/src/validate_result.rs
+++ b/crates/rivers-runtime/src/validate_result.rs
@@ -622,6 +622,10 @@ pub mod error_codes {
     /// `sqlite`). Multi-instance dedupe does not work in this configuration —
     /// every node fires every tick. CB-P1.14 / `rivers-cron-view-spec.md` §5.3.
     pub const W011: &str = "W011";
+    /// OTLP view declared `max_body_mb` greater than 16. OTLP/HTTP recommends
+    /// 4; values that large are almost certainly a misconfiguration. Accepted
+    /// but flagged. CB-OTLP / `rivers-otlp-view-spec.md` §9 (W-OTLP-1).
+    pub const W012: &str = "W012";
 }
 
 // ── Tests ──────────────────────────────────────────────────────────

--- a/crates/rivers-runtime/src/validate_structural.rs
+++ b/crates/rivers-runtime/src/validate_structural.rs
@@ -108,6 +108,8 @@ const VIEW_FIELDS: &[&str] = &[
     "response_headers", "guard_view",
     // Cron view fields (CB-P1.14 Track 3)
     "schedule", "interval_seconds", "overlap_policy", "max_concurrent",
+    // OTLP view fields (CB-OTLP Track O1 — docs/arch/rivers-otlp-view-spec.md)
+    "handlers", "max_body_mb",
 ];
 const VIEW_REQUIRED: &[&str] = &["path", "method", "view_type", "handler"];
 
@@ -117,7 +119,7 @@ const VIEW_REQUIRED: &[&str] = &["path", "method", "view_type", "handler"];
 /// layer instead of letting them slip through to runtime as silent no-ops.
 /// Sprint 2026-05-09 Track 2 + Track 3 (added `Cron`).
 const VALID_VIEW_TYPES: &[&str] = &[
-    "Rest", "Websocket", "ServerSentEvents", "MessageConsumer", "Mcp", "Cron",
+    "Rest", "Websocket", "ServerSentEvents", "MessageConsumer", "Mcp", "Cron", "OTLP",
 ];
 
 /// Canonical `overlap_policy` values for Cron views (CB-P1.14 Track 3).
@@ -792,11 +794,14 @@ fn validate_view(
     // MessageConsumer views are event-driven — no HTTP route, so path/method
     // are forbidden by the runtime validator (see crates/riversd/src/
     // view_engine/validation.rs). Cron views are time-driven, same shape:
-    // no HTTP route. Restrict the required-fields check to the common
-    // view_type + handler pair for those views.
+    // no HTTP route. OTLP views have their own handler shape (single `handler`
+    // OR `handlers.{metrics,logs,traces}` table) and forbid `method`, so the
+    // shared `VIEW_REQUIRED` check is replaced by per-view rules below.
     let view_type = table.get("view_type").and_then(|v| v.as_str()).unwrap_or("");
     let required: &[&str] = if view_type == "MessageConsumer" || view_type == "Cron" {
         &["view_type", "handler"]
+    } else if view_type == "OTLP" {
+        &["view_type", "path"]
     } else {
         VIEW_REQUIRED
     };
@@ -805,6 +810,10 @@ fn validate_view(
     // Cron-view-specific structural rules (CB-P1.14, Track 3).
     if view_type == "Cron" {
         validate_cron_view(table, file, table_path, app_name, results);
+    } else if view_type == "OTLP" {
+        // OTLP-view-specific structural rules (CB-OTLP Track O1 —
+        // docs/arch/rivers-otlp-view-spec.md §9).
+        validate_otlp_view(table, file, table_path, app_name, results);
     } else {
         // Cron-only fields on non-Cron views are no-ops at runtime — flag as
         // S005 so the misuse surfaces at validation rather than silently.
@@ -816,6 +825,24 @@ fn validate_view(
                         file,
                         format!(
                             "{}.{} is only valid when view_type=\"Cron\"",
+                            table_path, f
+                        ),
+                    )
+                    .with_table_path(table_path)
+                    .with_field(*f)
+                    .with_app(app_name),
+                );
+            }
+        }
+        // OTLP-only fields on non-OTLP views — same rationale.
+        for f in &["handlers", "max_body_mb"] {
+            if table.contains_key(*f) {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S005,
+                        file,
+                        format!(
+                            "{}.{} is only valid when view_type=\"OTLP\"",
                             table_path, f
                         ),
                     )
@@ -1163,6 +1190,275 @@ fn validate_cron_view(
                     )
                     .with_table_path(table_path)
                     .with_field("overlap_policy")
+                    .with_app(app_name),
+                );
+            }
+        }
+    }
+}
+
+/// Walks `[api.views.<name>]` when `view_type = "OTLP"` and enforces structural
+/// rules from `docs/arch/rivers-otlp-view-spec.md` §9. CB-OTLP Track O1.
+///
+/// All errors are emitted as `S005` with a `[X-OTLP-N]` marker in the message
+/// so the spec-doc traceability codes remain searchable. Layer 1 only —
+/// X-OTLP-7/8 (module exists, entrypoint exported) require the parsed
+/// `handlers` field and live in `validate_crossref` once O2 lands it.
+///
+/// Rules enforced here:
+/// - **X-OTLP-1** — `path` ends with `/v1/{metrics,logs,traces}`. Implies the
+///   operator is mounting OTLP under a non-OTLP view type.
+/// - **X-OTLP-2** — neither `handler` nor any `handlers.*` declared.
+/// - **X-OTLP-3** — `auth` is anything other than `"none"`. OTLP clients are
+///   stateless; `"session"` and `"bearer"` are both rejected. Bearer-style
+///   auth uses `guard_view` per the existing project pattern.
+/// - **X-OTLP-4** — `streaming = true`. OTLP/HTTP is unary.
+/// - **X-OTLP-5** — both `handler` and `handlers.*` declared (mutually exclusive).
+/// - **X-OTLP-6** — any forbidden field declared (see `OTLP_FORBIDDEN`).
+/// - **W-OTLP-1** — `max_body_mb > 16`. OTLP/HTTP recommends 4. Warning, not
+///   error, because some operators may legitimately accept large batches.
+fn validate_otlp_view(
+    table: &toml::value::Table,
+    file: &str,
+    table_path: &str,
+    app_name: &str,
+    results: &mut Vec<ValidationResult>,
+) {
+    // X-OTLP-6: forbidden fields. These have no meaning on an OTLP view —
+    // method is hard-coded POST; streaming is forbidden by spec; the other
+    // fields belong to other view types.
+    const OTLP_FORBIDDEN: &[&str] = &[
+        "method",
+        "streaming_format", "stream_timeout_ms",
+        "polling",
+        "websocket_mode", "max_connections",
+        "sse_tick_interval_ms", "sse_trigger_events", "sse_event_buffer_size",
+        "session_revalidation_interval_s",
+        "tools", "resources", "prompts", "instructions", "session", "federation",
+        "schedule", "interval_seconds", "overlap_policy", "max_concurrent",
+        "primary", "dataviews",
+    ];
+    for f in OTLP_FORBIDDEN {
+        if table.contains_key(*f) {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "[X-OTLP-6] {}.{} is not allowed on view_type=\"OTLP\"",
+                        table_path, f
+                    ),
+                )
+                .with_table_path(table_path)
+                .with_field(*f)
+                .with_app(app_name),
+            );
+        }
+    }
+
+    // X-OTLP-1: path ends with one of the OTLP signal suffixes. The framework
+    // mounts /v1/{metrics,logs,traces} under the declared root prefix; if the
+    // operator already wrote one of those suffixes the mount would be doubled.
+    if let Some(p) = table.get("path").and_then(|v| v.as_str()) {
+        let trimmed = p.trim_end_matches('/');
+        for suffix in &["/v1/metrics", "/v1/logs", "/v1/traces"] {
+            if trimmed.ends_with(suffix) {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S005,
+                        file,
+                        format!(
+                            "[X-OTLP-1] {}.path '{}' must not end with '{}' — the OTLP view mounts /v1/{{metrics,logs,traces}} under the declared root; use path = \"otel\" (or similar prefix)",
+                            table_path, p, suffix
+                        ),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("path")
+                    .with_app(app_name),
+                );
+                break;
+            }
+        }
+    }
+
+    // X-OTLP-3: auth must be "none" only. Session is rejected because OTLP is
+    // stateless; bearer is rejected because the project resolved P1.12 by
+    // routing bearer auth through `guard_view` rather than adding "bearer" to
+    // VALID_AUTH_MODES.
+    if let Some(au_val) = table.get("auth") {
+        match au_val.as_str() {
+            Some("none") => {}
+            Some(other) => {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S005,
+                        file,
+                        format!(
+                            "[X-OTLP-3] {}.auth '{}' is not allowed on view_type=\"OTLP\" — only \"none\" is accepted; use `guard_view = \"...\"` for bearer-style auth",
+                            table_path, other
+                        ),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("auth")
+                    .with_app(app_name),
+                );
+            }
+            None => {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S004,
+                        file,
+                        format!("{}.auth must be a string", table_path),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("auth")
+                    .with_app(app_name),
+                );
+            }
+        }
+    }
+
+    // X-OTLP-4: streaming = true. OTLP/HTTP is unary — no chunked response.
+    if let Some(s) = table.get("streaming").and_then(|v| v.as_bool()) {
+        if s {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "[X-OTLP-4] {}.streaming = true is not allowed on view_type=\"OTLP\" — OTLP/HTTP is unary",
+                        table_path
+                    ),
+                )
+                .with_table_path(table_path)
+                .with_field("streaming")
+                .with_app(app_name),
+            );
+        }
+    }
+
+    // X-OTLP-2 / X-OTLP-5: handler discriminator.
+    let has_handler = table.contains_key("handler");
+    let handlers_tbl = table.get("handlers").and_then(|v| v.as_table());
+    let has_any_signal_handler = handlers_tbl
+        .map(|t| t.contains_key("metrics") || t.contains_key("logs") || t.contains_key("traces"))
+        .unwrap_or(false);
+
+    match (has_handler, has_any_signal_handler) {
+        (true, true) => {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "[X-OTLP-5] {} declares both `handler` and `handlers.*` — exactly one form is allowed for view_type=\"OTLP\"",
+                        table_path
+                    ),
+                )
+                .with_table_path(table_path)
+                .with_app(app_name),
+            );
+        }
+        (false, false) => {
+            results.push(
+                ValidationResult::fail(
+                    error_codes::S005,
+                    file,
+                    format!(
+                        "[X-OTLP-2] {} requires either a single `handler` block or at least one of `handlers.{{metrics,logs,traces}}` for view_type=\"OTLP\"",
+                        table_path
+                    ),
+                )
+                .with_table_path(table_path)
+                .with_app(app_name),
+            );
+        }
+        _ => {}
+    }
+
+    // If the multi-handler form is present, validate each signal sub-table the
+    // same way the single `handler` table is validated above the call site
+    // (HANDLER_FIELDS / HANDLER_REQUIRED). Also reject unknown signal names.
+    if let Some(t) = handlers_tbl {
+        for (signal_name, signal_val) in t {
+            let signal_path = format!("{}.handlers.{}", table_path, signal_name);
+            if !matches!(signal_name.as_str(), "metrics" | "logs" | "traces") {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S005,
+                        file,
+                        format!(
+                            "[X-OTLP-2] {} is not a recognised OTLP signal — only 'metrics', 'logs', and 'traces' are valid handler keys",
+                            signal_path
+                        ),
+                    )
+                    .with_table_path(&signal_path)
+                    .with_app(app_name),
+                );
+                continue;
+            }
+            if let Some(signal_table) = signal_val.as_table() {
+                check_unknown_keys(signal_table, HANDLER_FIELDS, file, &signal_path, results);
+                check_required_fields(signal_table, HANDLER_REQUIRED, file, &signal_path, results);
+            } else {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S004,
+                        file,
+                        format!("{} must be a table", signal_path),
+                    )
+                    .with_table_path(&signal_path)
+                    .with_app(app_name),
+                );
+            }
+        }
+    }
+
+    // W-OTLP-1: max_body_mb > 16 is a warning. Spec recommends 4; values above
+    // 16 are almost certainly a misconfiguration. Allowed but flagged. Emitted
+    // as W012 per `validate_result::error_codes`.
+    if let Some(mb_val) = table.get("max_body_mb") {
+        match mb_val.as_integer() {
+            Some(n) if n > 16 => {
+                let _ = file; // warnings carry no file per existing convention
+                results.push(
+                    ValidationResult::warn(
+                        error_codes::W012,
+                        format!(
+                            "[W-OTLP-1] {}.max_body_mb = {} is unusually large (OTLP/HTTP recommends 4); accepting but flagging",
+                            table_path, n
+                        ),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("max_body_mb")
+                    .with_app(app_name),
+                );
+            }
+            Some(n) if n < 1 => {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S005,
+                        file,
+                        format!(
+                            "{}.max_body_mb must be >= 1, got {}",
+                            table_path, n
+                        ),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("max_body_mb")
+                    .with_app(app_name),
+                );
+            }
+            Some(_) => {}
+            None => {
+                results.push(
+                    ValidationResult::fail(
+                        error_codes::S004,
+                        file,
+                        format!("{}.max_body_mb must be a positive integer", table_path),
+                    )
+                    .with_table_path(table_path)
+                    .with_field("max_body_mb")
                     .with_app(app_name),
                 );
             }
@@ -2685,6 +2981,453 @@ dataview = "items"
                 f,
                 results.iter().map(|r| &r.message).collect::<Vec<_>>());
         }
+    }
+
+    // ── CB-OTLP Track O1: OTLP view validation (rivers-otlp-view-spec.md §9) ─
+
+    fn write_otlp_view(dir: &Path, body: &str) {
+        std::fs::write(
+            dir.join("test-app/app.toml"),
+            format!(r#"
+[data.dataviews.items]
+name       = "items"
+datasource = "data"
+
+{}
+"#, body),
+        ).unwrap();
+    }
+
+    #[test]
+    fn otlp_view_accepts_multi_handler_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+auth      = "none"
+
+[api.views.otel_ingest.handlers.metrics]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+resources  = []
+
+[api.views.otel_ingest.handlers.logs]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestLogs"
+resources  = []
+
+[api.views.otel_ingest.handlers.traces]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestTraces"
+resources  = []
+"#);
+        let results = validate_structural(&bundle_dir);
+        let view_failures: Vec<_> = results.iter()
+            .filter(|r| r.status == ValidationStatus::Fail
+                && r.table_path.as_deref()
+                    .map(|p| p.contains("otel_ingest"))
+                    .unwrap_or(false))
+            .collect();
+        assert!(view_failures.is_empty(),
+            "expected no failures on canonical OTLP multi-handler view, got: {:?}",
+            view_failures.iter().map(|r| &r.message).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn otlp_view_accepts_single_handler_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestAny"
+resources  = []
+"#);
+        let results = validate_structural(&bundle_dir);
+        let view_failures: Vec<_> = results.iter()
+            .filter(|r| r.status == ValidationStatus::Fail
+                && r.table_path.as_deref()
+                    .map(|p| p.contains("otel_ingest"))
+                    .unwrap_or(false))
+            .collect();
+        assert!(view_failures.is_empty(),
+            "expected no failures on canonical OTLP single-handler view, got: {:?}",
+            view_failures.iter().map(|r| &r.message).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn otlp_view_accepts_metrics_only_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.metrics_only]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.metrics_only.handlers.metrics]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+"#);
+        let results = validate_structural(&bundle_dir);
+        let view_failures: Vec<_> = results.iter()
+            .filter(|r| r.status == ValidationStatus::Fail
+                && r.table_path.as_deref()
+                    .map(|p| p.contains("metrics_only"))
+                    .unwrap_or(false))
+            .collect();
+        assert!(view_failures.is_empty(),
+            "expected no failures on metrics-only OTLP view, got: {:?}",
+            view_failures.iter().map(|r| &r.message).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn otlp_view_rejects_path_ending_in_signal_x_otlp_1() {
+        for suffix in &["/v1/metrics", "/v1/logs", "/v1/traces"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let bundle_dir = create_valid_bundle(tmp.path());
+            let body = format!(r#"
+[api.views.bad]
+path      = "otel{}"
+view_type = "OTLP"
+
+[api.views.bad.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestAny"
+"#, suffix);
+            write_otlp_view(&bundle_dir, &body);
+            let results = validate_structural(&bundle_dir);
+            assert!(results.iter().any(|r|
+                r.error_code.as_deref() == Some("S005")
+                && r.message.contains("[X-OTLP-1]")
+                && r.field.as_deref() == Some("path")
+            ), "expected [X-OTLP-1] on OTLP path ending in '{}', got: {:?}",
+                suffix,
+                results.iter().map(|r| &r.message).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn otlp_view_rejects_missing_handler_x_otlp_2() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.no_handler]
+path      = "otel"
+view_type = "OTLP"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-2]")
+            && r.message.contains("requires either a single `handler`")
+        ), "expected [X-OTLP-2] when no handler declared, got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_unknown_signal_x_otlp_2() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.otel_ingest.handlers.bogus]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-2]")
+            && r.message.contains("is not a recognised OTLP signal")
+        ), "expected [X-OTLP-2] on unknown signal 'bogus', got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_auth_session_x_otlp_3() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+auth      = "session"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-3]")
+            && r.field.as_deref() == Some("auth")
+        ), "expected [X-OTLP-3] on auth='session', got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_auth_bearer_x_otlp_3() {
+        // "bearer" is not in VALID_AUTH_MODES; the OTLP validator rejects it
+        // with the OTLP-specific [X-OTLP-3] message before the generic auth
+        // validator runs, so the project's existing guard_view pattern is
+        // surfaced in the error.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+auth      = "bearer"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-3]")
+            && r.message.contains("guard_view")
+        ), "expected [X-OTLP-3] on auth='bearer' pointing at guard_view, got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_streaming_x_otlp_4() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+streaming = true
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-4]")
+            && r.field.as_deref() == Some("streaming")
+        ), "expected [X-OTLP-4] on streaming=true, got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_both_handler_forms_x_otlp_5() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestAny"
+
+[api.views.otel_ingest.handlers.metrics]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.message.contains("[X-OTLP-5]")
+            && r.message.contains("declares both `handler` and `handlers.*`")
+        ), "expected [X-OTLP-5] on both handler forms, got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_forbidden_fields_x_otlp_6() {
+        // method, streaming_format, websocket_mode, tools, schedule are all
+        // unrelated view-type fields with no meaning on OTLP. Each must
+        // surface its own [X-OTLP-6].
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path             = "otel"
+view_type        = "OTLP"
+method           = "POST"
+streaming_format = "ndjson"
+websocket_mode   = "Broadcast"
+schedule         = "0 * * * * *"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        for forbidden in &["method", "streaming_format", "websocket_mode", "schedule"] {
+            assert!(results.iter().any(|r|
+                r.error_code.as_deref() == Some("S005")
+                && r.message.contains("[X-OTLP-6]")
+                && r.field.as_deref() == Some(*forbidden)
+            ), "expected [X-OTLP-6] on OTLP view with forbidden field '{}', got: {:?}",
+                forbidden,
+                results.iter().map(|r| &r.message).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn otlp_view_warns_on_large_max_body_mb_w_otlp_1() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path        = "otel"
+view_type   = "OTLP"
+max_body_mb = 64
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.status == ValidationStatus::Warn
+            && r.error_code.as_deref() == Some("W012")
+            && r.message.contains("[W-OTLP-1]")
+            && r.field.as_deref() == Some("max_body_mb")
+        ), "expected W012 [W-OTLP-1] on max_body_mb=64, got: {:?}",
+            results.iter().map(|r| (r.status, &r.message)).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_view_rejects_invalid_max_body_mb() {
+        // < 1 is a hard error, not a warning.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.otel_ingest]
+path        = "otel"
+view_type   = "OTLP"
+max_body_mb = 0
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        assert!(results.iter().any(|r|
+            r.status == ValidationStatus::Fail
+            && r.error_code.as_deref() == Some("S005")
+            && r.field.as_deref() == Some("max_body_mb")
+            && r.message.contains("must be >= 1")
+        ), "expected S005 on max_body_mb=0, got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn otlp_only_fields_rejected_on_rest_view() {
+        // handlers / max_body_mb on a non-OTLP view are no-ops at runtime —
+        // surface them.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        std::fs::write(
+            bundle_dir.join("test-app/app.toml"),
+            r#"
+[data.dataviews.items]
+name = "items"
+datasource = "data"
+
+[api.views.items]
+path        = "items"
+method      = "GET"
+view_type   = "Rest"
+auth        = "none"
+max_body_mb = 4
+
+[api.views.items.handler]
+type     = "dataview"
+dataview = "items"
+
+[api.views.items.handlers.metrics]
+type = "codecomponent"
+"#,
+        ).unwrap();
+        let results = validate_structural(&bundle_dir);
+        for f in &["handlers", "max_body_mb"] {
+            assert!(results.iter().any(|r|
+                r.error_code.as_deref() == Some("S005")
+                && r.field.as_deref() == Some(*f)
+                && r.message.contains("only valid when view_type=\"OTLP\"")
+            ), "expected S005 on Rest view with OTLP-only field '{}', got: {:?}",
+                f,
+                results.iter().map(|r| &r.message).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn typo_otl_still_produces_unknown_view_type_error() {
+        // A typo like `view_type = "OTL"` must NOT be handled by the OTLP
+        // validator — it must fall through to the generic unknown-view-type
+        // path so the existing did-you-mean hint kicks in.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_dir = create_valid_bundle(tmp.path());
+        write_otlp_view(&bundle_dir, r#"
+[api.views.bad]
+path      = "otel"
+view_type = "OTL"
+
+[api.views.bad.handler]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "x"
+"#);
+        let results = validate_structural(&bundle_dir);
+        // Expect the generic unknown-view-type S005 (no [X-OTLP-N] marker).
+        assert!(results.iter().any(|r|
+            r.error_code.as_deref() == Some("S005")
+            && r.field.as_deref() == Some("view_type")
+            && r.message.contains("'OTL'")
+            && r.message.contains("is not one of")
+        ), "expected generic S005 on view_type='OTL', got: {:?}",
+            results.iter().map(|r| &r.message).collect::<Vec<_>>());
+        // Must NOT have any [X-OTLP-N] errors — the OTLP validator must not
+        // have run on this view.
+        let otlp_specific: Vec<_> = results.iter()
+            .filter(|r| r.message.contains("[X-OTLP-"))
+            .collect();
+        assert!(otlp_specific.is_empty(),
+            "OTLP validator should not run on typo'd view_type, got OTLP-specific errors: {:?}",
+            otlp_specific.iter().map(|r| &r.message).collect::<Vec<_>>());
     }
 
     // ── Multiple errors collected ─────────────────────────────────

--- a/docs/arch/rivers-bundle-validation-spec.md
+++ b/docs/arch/rivers-bundle-validation-spec.md
@@ -174,7 +174,7 @@ Fail → app enters FAILED state, structured error logged
 **Per-app `app.toml` structural rules:**
 
 - `[data.dataviews.*]` — each DataView has `name` (string), `datasource` (string), `query` (string)
-- `[api.views.*]` — each view has `path` (string), `method` (string), `view_type` (string, must be `Rest`, `Websocket`, `ServerSentEvents`, `MessageConsumer`, or `Mcp`); optional `auth` (string, must be `none` or `session` if present). Values outside these closed sets emit `S005` with a did-you-mean hint (Sprint 2026-05-09 Track 2).
+- `[api.views.*]` — each view has `path` (string), `method` (string), `view_type` (string, must be `Rest`, `Websocket`, `ServerSentEvents`, `MessageConsumer`, `Mcp`, `Cron`, or `OTLP`); optional `auth` (string, must be `none` or `session` if present — `OTLP` views accept only `none`). Values outside these closed sets emit `S005` with a did-you-mean hint (Sprint 2026-05-09 Track 2; `Cron` added Track 3; `OTLP` added Sprint 2026-05-XX Track O1).
 - Handler definitions: `type` is `"dataview"` or `"codecomponent"`; CodeComponent requires `language`, `module`, `entrypoint`
 - `nopassword = true` and `lockbox` are mutually exclusive — presence of both is a hard error
 - `nopassword` absent and `lockbox` absent is a hard error (for non-`nopassword` drivers)
@@ -752,6 +752,30 @@ The `--lint` flag is removed from `riversctl doctor`. `doctor` retains its syste
 | `W002` | `Layer 4 skipped — engine dylib not available for {engine}` |
 | `W003` | `Layer 4 skipped — riversd.toml not found` |
 | `W004` | `{app}: no views defined — check [api.views.*] (not [views.*])` |
+| `W005` | `{file}: skip_introspect = true on a DataView with a GET query — likely a misconfiguration` |
+| `W006` | `{file}: subscribable = true on an MCP resource whose bound DataView has no GET method` |
+| `W007` | `{file}: cursor_key is set but the query has no ORDER BY clause (cursor pagination requires deterministic ordering)` |
+| `W008` | `{file}: transaction=true on a DataView backed by a driver that does not support transactions` |
+| `W009` | `{file}: guard_view target has auth = "session" — sessions don't exist when the guard runs` |
+| `W010` | `{file}: view has both guard = true (server-wide auth gate) and guard_view = "..." (per-view gate)` |
+| `W011` | `Cron views declared with a node-local storage backend ({backend}); multi-instance dedupe does not work` |
+| `W012` | `OTLP view: {field} = {value} is unusually large (OTLP/HTTP recommends 4); accepting but flagging` |
+
+### 11.5.1 X-OTLP-N marker convention
+
+OTLP-view-specific structural failures are emitted as `S005` (the existing invalid-value code) with a `[X-OTLP-N]` marker prepended to the message. The markers correspond to spec rules in `docs/arch/rivers-otlp-view-spec.md` §9 and let docs/agents grep for specific OTLP failure modes without introducing per-rule error codes:
+
+| Marker | Condition |
+|---|---|
+| `[X-OTLP-1]` | `path` ends with `/v1/{metrics,logs,traces}` — operator is mounting OTLP under a non-OTLP view type |
+| `[X-OTLP-2]` | Neither `handlers.{metrics,logs,traces}` nor a single `handler` declared, OR an unknown handler signal name |
+| `[X-OTLP-3]` | `auth` is anything other than `"none"` (OTLP is stateless; use `guard_view` for bearer-style auth) |
+| `[X-OTLP-4]` | `streaming = true` (OTLP/HTTP is unary) |
+| `[X-OTLP-5]` | Both single `handler` and `handlers.*` declared (mutually exclusive) |
+| `[X-OTLP-6]` | A field from another view type's domain is declared on an OTLP view |
+| `[W-OTLP-1]` | `max_body_mb > 16` — emitted as `W012`, not `S005` |
+
+`[X-OTLP-7]` and `[X-OTLP-8]` (Layer 3 module/entrypoint resolution for the `handlers.*` table) land when the dispatcher ships — see `rivers-otlp-view-spec.md` §14.3.
 
 ### 11.6 Gate 2 live check errors
 

--- a/docs/arch/rivers-feature-inventory.md
+++ b/docs/arch/rivers-feature-inventory.md
@@ -119,6 +119,17 @@ Extracted from all specification documents. Top-level features with granular sub
 - Same execution environment as REST/MCP — `Rivers.db.*` capability propagation works
 - Spec: `docs/arch/rivers-cron-view-spec.md`
 
+### 2.6c OTLP Views (CB-OTLP, Sprint 2026-05-XX)
+- Declarative OpenTelemetry OTLP/HTTP endpoint — framework owns wire format, handler owns business logic
+- Content-Type negotiation between `application/json` and `application/x-protobuf` (reuses P1.6 transcoder)
+- Auto-decompression of `Content-Encoding: gzip` / `deflate` with `max_body_mb × 1.5` amplification cap
+- Operator declares `path = "<prefix>"`; framework mounts `/v1/{metrics,logs,traces}` underneath
+- Multi-handler form (`handlers.{metrics,logs,traces}`) or single-handler form with `ctx.otel.kind` discriminator
+- Framework emits OTLP-spec partial-success response (`{partialSuccess: {rejected<X>: N, errorMessage: "..."}}`)
+- Validator codes `[X-OTLP-1..6]` (errors) and `[W-OTLP-1]` (warning) — see `docs/arch/rivers-bundle-validation-amendments.md`
+- Track O1 (validator + inventory entry) shipped first; Track O2 (dispatcher + gzip + response wrap) follows
+- Spec: `docs/arch/rivers-otlp-view-spec.md`
+
 ### 2.7 Streaming REST
 - POST with streaming response body
 - Wire formats: NDJSON (`application/x-ndjson`) and SSE (`text/event-stream`)

--- a/docs/arch/rivers-otlp-view-spec.md
+++ b/docs/arch/rivers-otlp-view-spec.md
@@ -1,0 +1,623 @@
+# Rivers OTLP View Specification
+
+**Document Type:** New spec
+**Scope:** `view_type = "OTLP"` — declarative OpenTelemetry OTLP/HTTP endpoint with framework-owned wire-format handling
+**Status:** Design / Pre-Implementation
+**Patches:** `rivers-view-layer-spec.md`, `rivers-feature-inventory.md`, `rivers-httpd-spec.md`
+**Source ask:** CB OTLP feature request bundle (`cb-rivers-otlp-feature-request.zip`, filed 2026-05-11)
+**Depends on:** P1.6 protobuf transcoder (shipped — [otlp_transcoder.rs](../../crates/riversd/src/otlp_transcoder.rs)); P1.12 `auth = "bearer"` (pending)
+
+---
+
+## Table of Contents
+
+1. [Design Rationale](#1-design-rationale)
+2. [Mental Model](#2-mental-model)
+3. [View Declaration](#3-view-declaration)
+4. [Wire Protocol Handling](#4-wire-protocol-handling)
+5. [Path Routing](#5-path-routing)
+6. [Handler Dispatch Envelope](#6-handler-dispatch-envelope)
+7. [Response Shape](#7-response-shape)
+8. [Auth](#8-auth)
+9. [Validation Rules](#9-validation-rules)
+10. [Configuration Reference](#10-configuration-reference)
+11. [Observability](#11-observability)
+12. [Examples](#12-examples)
+13. [Non-goals (v1)](#13-non-goals-v1)
+14. [Implementation Notes](#14-implementation-notes)
+
+---
+
+## 1. Design Rationale
+
+### 1.1 The problem
+
+OpenTelemetry's OTLP/HTTP protocol is the industry standard for telemetry ingestion (metrics + logs + traces). Today, Rivers operators who want to receive OTLP have to stand up three near-identical `view_type = "Rest"` views — one per signal type — and hand-decode the OTLP envelope inside a codecomponent handler. The hand-rolled path works for `application/json` with no compression but fails the moment a real OTLP client appears with `application/x-protobuf` or `Content-Encoding: gzip` — i.e., production defaults for OTel SDKs and the OTel Collector.
+
+A native `view_type = "OTLP"` collapses the workaround into one declarative block, surfaces existing capabilities the framework already has, and adds the few missing wire-format pieces (gzip, partial-success response).
+
+### 1.2 What's already there — the implementation lever
+
+Rivers v0.61.1 already ships an OTLP protobuf transcoder ([crates/riversd/src/otlp_transcoder.rs](../../crates/riversd/src/otlp_transcoder.rs), 77 lines), wired into [view_dispatch.rs](../../crates/riversd/src/server/view_dispatch.rs) at the body-extraction stage. When a REST request arrives with `Content-Type: application/x-protobuf` and a path ending in `/v1/{traces,metrics,logs}`, the framework decodes the prost message and re-encodes as JSON before handing off to the handler.
+
+This means the asked feature is **not** a new wire-format parser. It is:
+
+- a declarative opt-in (`view_type = "OTLP"`) to the existing transcoder,
+- gzip/deflate decompression (new, but ~30 lines via `flate2`),
+- path-based per-signal dispatch (small router on top of existing handler config),
+- partial-success response envelope (output transform, ~20 lines).
+
+The cost calculus favors implementing it cleanly rather than continuing to ask every handler to reinvent the same boilerplate.
+
+### 1.3 Ownership boundary
+
+- **Framework MUST** — content-type negotiation between JSON and protobuf, gzip/deflate decompression, path-based dispatch to per-signal handlers, partial-success response wrapping, body-size enforcement.
+- **Developer MUST** — per-signal handler bodies (or one handler with a `kind` discriminator), declaring `auth` (when P1.12 lands), declaring resources.
+- **Framework MUST NOT** — interpret payload semantics beyond decoding the envelope, persist telemetry on the developer's behalf, transform individual data points.
+
+### 1.4 Precedent in the codebase
+
+Same architectural level as `view_type = "Mcp"` (JSON-RPC envelope + tool dispatch), `view_type = "ServerSentEvents"` (SSE framing + tick scheduler), and `view_type = "Cron"` (tick scheduler + no client). The framework owns the protocol; the developer owns the per-row business logic.
+
+### 1.5 Key decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Wire formats | JSON + protobuf (transcoded to JSON before dispatch) | Reuses P1.6 transcoder; handler stays JSON-uniform |
+| Compression | gzip + deflate (auto-decompressed before transcode) | Matches OTel SDK defaults |
+| Per-signal dispatch | `handlers.{metrics,logs,traces}` table OR single `handler` with `ctx.otel.kind` discriminator | First is more declarative; second is simpler for one-handler bundles |
+| Response on success | `200 {}` | OTLP spec — empty success envelope |
+| Response on partial success | `200 {partialSuccess: {rejectedDataPoints, errorMessage}}` | OTLP spec — partial success is still a 200 |
+| Response on hard failure | `4xx`/`5xx` with `application/json` `{error: "..."}` | Matches existing REST error responses |
+| Streaming | Forbidden | OTLP/HTTP is unary; rejected at validation (X-OTLP-4) |
+| Path | Operator declares root prefix (e.g., `path = "otel"`), framework mounts `/v1/{metrics,logs,traces}` underneath | Avoids fragile per-signal `path` repetition |
+
+---
+
+## 2. Mental Model
+
+```
+Inbound POST /otel/v1/metrics
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│ OTLP view dispatcher (framework-owned)      │
+│                                             │
+│  1. Body size check vs max_body_mb          │
+│  2. Content-Encoding: gunzip / inflate      │
+│  3. Content-Type:                            │
+│       application/x-protobuf → P1.6         │
+│         transcoder → JSON                   │
+│       application/json → pass through       │
+│  4. Path tail (/v1/metrics, /v1/logs,       │
+│     /v1/traces) → pick handler              │
+│  5. Build ctx.otel = {kind, payload, ...}   │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+  Dispatch handler (codecomponent)
+    │
+  Same capability propagation as REST/MCP/Cron
+    │
+    ▼
+  Handler returns; framework reads
+  ctx.otel.rejected + ctx.otel.errorMessage
+    │
+    ▼
+  Framework emits:
+    200 {}                                  (success)
+    200 {partialSuccess: {...}}             (partial)
+    4xx/5xx {error: "..."}                  (hard fail)
+```
+
+---
+
+## 3. View Declaration
+
+### 3.1 Multi-handler form (recommended)
+
+```toml
+[api.views.otel_ingest]
+path         = "otel"            # framework mounts /otel/v1/{metrics,logs,traces}
+view_type    = "OTLP"
+auth         = "bearer"          # if/when P1.12 lands; "none" otherwise
+max_body_mb  = 4                 # OTLP spec default; optional, defaults below
+
+[api.views.otel_ingest.handlers.metrics]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+resources  = ["cb_db"]
+
+[api.views.otel_ingest.handlers.logs]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestLogs"
+resources  = ["cb_db"]
+
+[api.views.otel_ingest.handlers.traces]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestTraces"
+resources  = ["cb_db"]
+```
+
+Partial declarations are allowed: an operator may declare only `handlers.metrics` to expose `/v1/metrics` and have `/v1/logs` and `/v1/traces` return `404`. The validator does **not** require all three signals — only that at least one is declared (X-OTLP-2).
+
+### 3.2 Single-handler form
+
+```toml
+[api.views.otel_ingest]
+path         = "otel"
+view_type    = "OTLP"
+auth         = "bearer"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestAny"
+resources  = ["cb_db"]
+```
+
+The same handler receives all three signal types with `ctx.otel.kind ∈ {"metrics", "logs", "traces"}` set by the framework. This is simpler when the per-signal logic is small or shares most code.
+
+`handler` and `handlers.*` are mutually exclusive — the validator rejects both at once (X-OTLP-5).
+
+### 3.3 Required fields
+
+| Field | Required? | Default | Notes |
+|---|---|---|---|
+| `view_type` | yes | — | Must be `"OTLP"` |
+| `path` | yes | — | Root prefix; framework mounts `/v1/{metrics,logs,traces}` underneath |
+| `handlers.metrics` ∨ `handlers.logs` ∨ `handlers.traces` ∨ `handler` | exactly one form, at least one signal | — | Per-signal table or single discriminator handler |
+| `auth` | optional | `"none"` | `"none"` or `"bearer"` only (bearer is P1.12-gated) |
+| `max_body_mb` | optional | `4` | Per the OTLP/HTTP spec recommendation |
+
+### 3.4 Forbidden fields
+
+| Field | Reason | Code |
+|---|---|---|
+| `method` | OTLP/HTTP is POST-only — framework hard-codes | X-OTLP-6 |
+| `streaming` / `streaming_format` / `stream_timeout_ms` | OTLP/HTTP is unary | X-OTLP-4 |
+| `polling`, `tick_interval_seconds` | No client subscription model | X-OTLP-6 |
+| `websocket_mode`, `max_connections` | Not a WS view | X-OTLP-6 |
+| `tools`, `resources`, `prompts`, `instructions` | MCP-only fields | X-OTLP-6 |
+| `schedule`, `interval_seconds`, `overlap_policy` | Cron-only fields | X-OTLP-6 |
+| `auth = "session"` | OTLP clients are stateless | X-OTLP-3 |
+
+---
+
+## 4. Wire Protocol Handling
+
+### 4.1 Content-Type negotiation
+
+| Inbound `Content-Type` | Framework behavior |
+|---|---|
+| `application/json` (or `application/json; charset=utf-8`) | Body parsed as JSON; passed through unchanged |
+| `application/x-protobuf` | Body fed to existing P1.6 `transcode_otlp_protobuf` → JSON |
+| Other / missing | `415 Unsupported Media Type`, body `{error: "OTLP requires application/json or application/x-protobuf"}` |
+
+The transcoder already lives in `crates/riversd/src/otlp_transcoder.rs` and matches on the path tail (`/v1/traces|metrics|logs`). The OTLP view reuses it directly — no new prost types are introduced.
+
+### 4.2 Content-Encoding (compression)
+
+Inspected before content-type processing:
+
+| Inbound `Content-Encoding` | Framework behavior |
+|---|---|
+| absent / `identity` | Body used as-is |
+| `gzip` | Decoded via `flate2::read::GzDecoder` |
+| `deflate` | Decoded via `flate2::read::DeflateDecoder` |
+| Other (e.g., `br`, `zstd`) | `415`, body `{error: "OTLP Content-Encoding '<x>' not supported"}` |
+
+Decompression is bounded: the decoded body is capped at `max_body_mb * 1.5` to prevent zip-bomb amplification. Exceeding the cap returns `413 Payload Too Large`.
+
+### 4.3 Body size enforcement
+
+Pre-decompression: reject `> max_body_mb` with `413`. Post-decompression: reject `> max_body_mb * 1.5` with `413` (amplification guard). Default `max_body_mb = 4` matches the OTLP/HTTP recommendation.
+
+### 4.4 Order of operations
+
+```
+Inbound bytes
+    │
+    ▼
+Size pre-check (max_body_mb)        → 413 on fail
+    │
+    ▼
+Decompress (gzip/deflate)           → 415 on unknown encoding
+    │
+    ▼
+Decompressed-size check (×1.5 cap)  → 413 on fail
+    │
+    ▼
+Decode by Content-Type:
+    application/x-protobuf → P1.6 transcoder → 415 on prost decode error
+    application/json       → serde_json::from_slice → 400 on parse error
+    other                  → 415
+    │
+    ▼
+JSON value → dispatcher
+```
+
+---
+
+## 5. Path Routing
+
+The view's declared `path` is the root prefix. The framework mounts the three OTLP signal endpoints underneath:
+
+| View `path` | Mounted endpoints |
+|---|---|
+| `"otel"` | `/otel/v1/metrics`, `/otel/v1/logs`, `/otel/v1/traces` |
+| `"telemetry/otel"` | `/telemetry/otel/v1/metrics`, etc. |
+| `"/"` (root) | `/v1/metrics`, `/v1/logs`, `/v1/traces` |
+
+For each signal:
+
+- If the corresponding `handlers.<signal>` block is declared, the framework dispatches to it.
+- If only the single `handler` form is declared, the framework dispatches there with `ctx.otel.kind = "<signal>"`.
+- If neither matches (e.g., `handlers.metrics` and `handlers.logs` are declared but a request hits `/v1/traces`), respond `404` with `{error: "OTLP signal 'traces' not configured on this view"}`.
+
+The validator rejects (`X-OTLP-1`) any `path` that itself ends in `/v1/metrics`, `/v1/logs`, or `/v1/traces` — that pattern implies the operator is trying to mount one OTLP path under a non-OTLP view type, which is exactly what `view_type = "OTLP"` exists to replace.
+
+---
+
+## 6. Handler Dispatch Envelope
+
+### 6.1 Inbound context
+
+Handlers receive the standard `ctx` shape plus an `otel` field:
+
+```json
+{
+  "request": {
+    "method":  "POST",
+    "path":    "/otel/v1/metrics",
+    "headers": { "content-type": "...", "...": "..." },
+    "body":    { "...": "..." },
+    "path_params": {},
+    "query":   {}
+  },
+  "session": null,
+  "otel": {
+    "kind":     "metrics",
+    "payload":  { "resourceMetrics": [ /* decoded shape */ ] },
+    "encoding": "json"
+  }
+}
+```
+
+- `ctx.otel.kind` — one of `"metrics"`, `"logs"`, `"traces"`. Set by the framework from the matched signal path.
+- `ctx.otel.payload` — the decoded OTLP envelope. Always JSON-shaped (protobuf inputs are transcoded first). For metrics it's `ExportMetricsServiceRequest`, for logs `ExportLogsServiceRequest`, for traces `ExportTraceServiceRequest`. Field naming matches the prost-derived JSON (camelCase keys per the canonical OTLP JSON encoding).
+- `ctx.otel.encoding` — `"json"` if the inbound `Content-Type` was JSON; `"protobuf"` if it was transcoded. Useful for diagnostics and metrics; handlers usually ignore it.
+- `ctx.request.body` is **also** set to `ctx.otel.payload` for handler-code compatibility with REST views.
+- `ctx.session` is populated when `auth = "bearer"` is configured and P1.12 has resolved the token; `null` otherwise.
+
+### 6.2 Outbound context (what the handler can set)
+
+Handlers may set the following on `ctx.otel` before returning:
+
+| Field | Type | Default | Effect |
+|---|---|---|---|
+| `rejected` | integer ≥ 0 | `0` | Count of rejected points/spans/log records |
+| `errorMessage` | string | `""` | Human-readable reason for the rejection |
+
+If `rejected > 0` the framework emits a partial-success body (§7.2). If `rejected == 0` (or the field is absent) the framework emits an empty success body (§7.1). Handlers that throw or return an error response trigger a hard failure (§7.3) — `partialSuccess` is only meaningful when the request itself was well-formed.
+
+The handler does **not** set HTTP status, response headers, or response body. The framework owns those for OTLP per spec compliance.
+
+---
+
+## 7. Response Shape
+
+### 7.1 Success
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{}
+```
+
+Per OTLP/HTTP spec: empty success envelope. The framework emits the same response for JSON and protobuf requests — protobuf clients receive JSON responses by default in v1. (See §13 non-goals for protobuf-response negotiation.)
+
+### 7.2 Partial success
+
+When `ctx.otel.rejected > 0`:
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "partialSuccess": {
+    "rejectedDataPoints": 3,
+    "errorMessage": "decision_id missing on tool_use_id 'abc'"
+  }
+}
+```
+
+The field name varies by signal kind:
+
+| Signal | Field name |
+|---|---|
+| metrics | `rejectedDataPoints` |
+| logs | `rejectedLogRecords` |
+| traces | `rejectedSpans` |
+
+Framework selects the right field from `ctx.otel.kind`.
+
+### 7.3 Hard failure
+
+For framework-level rejections (size, decode, content-type) and uncaught handler errors:
+
+```
+HTTP/1.1 <status> <reason>
+Content-Type: application/json
+
+{"error": "<message>"}
+```
+
+| Status | Cause |
+|---|---|
+| `400` | JSON parse error (well-formed protobuf is never a `400` — it's a `415`) |
+| `401` / `403` | Auth failure (when `auth = "bearer"` is enabled and the token is missing/invalid) |
+| `413` | Body exceeds `max_body_mb` (pre- or post-decompression) |
+| `415` | Unsupported `Content-Type` or `Content-Encoding`, or protobuf decode failure |
+| `500` | Handler threw an uncaught exception |
+
+---
+
+## 8. Auth
+
+`auth = "bearer"` is the only authenticated mode supported for OTLP views. Session auth is rejected at validation (X-OTLP-3) — OTLP clients are stateless and do not carry cookies.
+
+Bearer auth depends on Rivers P1.12 (per `cb-rivers-feature-request.md`). Until P1.12 lands, the spec calls for `auth = "bearer"` to validate and parse but emit a runtime warning at startup that bearer enforcement is not yet active (matches the pattern used for other pending features). Operators can deploy handlers using the in-handler bearer shim today; switching to `auth = "bearer"` requires no handler changes once P1.12 lands.
+
+When `auth = "bearer"` is active, the framework:
+
+1. Reads `Authorization: Bearer <token>` from the request headers.
+2. Resolves the token via the existing P1.12 bearer-auth pipeline.
+3. Populates `ctx.session` with the resolved principal before handler dispatch.
+4. Returns `401 {error: "missing or invalid bearer token"}` on failure.
+
+`auth = "none"` (the default) skips all of the above — useful for in-cluster ingest where the network boundary provides isolation.
+
+---
+
+## 9. Validation Rules
+
+Validation runs at the `validate_structural` and `validate_crossref` layers in the existing 4-layer pipeline ([rivers-bundle-validation-spec.md](rivers-bundle-validation-spec.md)).
+
+| Code | Layer | Condition | Severity |
+|---|---|---|---|
+| X-OTLP-1 | structural | `path` ends with `/v1/metrics`, `/v1/logs`, or `/v1/traces` — operator is mounting OTLP under a non-OTLP view type | error |
+| X-OTLP-2 | structural | Neither `handlers.{metrics,logs,traces}` nor a single `handler` block declared | error |
+| X-OTLP-3 | structural | `auth = "session"` declared — OTLP is stateless | error |
+| X-OTLP-4 | structural | `streaming = true` declared — OTLP/HTTP is unary | error |
+| X-OTLP-5 | structural | Both `handler` and `handlers.*` declared — choose one | error |
+| X-OTLP-6 | structural | Any forbidden field declared (see §3.4) | error |
+| X-OTLP-7 | crossref | A declared handler's `module` does not resolve to a file in the bundle | error |
+| X-OTLP-8 | crossref | A declared handler's `entrypoint` is not exported from `module` | error |
+| W-OTLP-1 | structural | `max_body_mb > 16` — likely a misconfiguration; OTLP recommends 4 | warning |
+| W-OTLP-2 | structural | `auth = "bearer"` declared while P1.12 has not yet landed | warning (suppressed once P1.12 ships) |
+
+---
+
+## 10. Configuration Reference
+
+```toml
+[api.views.<name>]
+view_type    = "OTLP"                # required
+path         = "<prefix>"            # required; framework appends /v1/<signal>
+auth         = "none" | "bearer"     # optional, default "none"
+max_body_mb  = <integer>             # optional, default 4
+
+# Multi-handler form (any subset of the three signals)
+[api.views.<name>.handlers.metrics]
+type       = "codecomponent"
+language   = "typescript" | "javascript"
+module     = "<path>"
+entrypoint = "<exported-fn>"
+resources  = [ "<resource>", ... ]
+
+[api.views.<name>.handlers.logs]
+# … same shape …
+
+[api.views.<name>.handlers.traces]
+# … same shape …
+
+# OR — single-handler form (mutually exclusive with handlers.*)
+[api.views.<name>.handler]
+type       = "codecomponent"
+language   = "typescript" | "javascript"
+module     = "<path>"
+entrypoint = "<exported-fn>"   # receives ctx.otel.kind discriminator
+resources  = [ "<resource>", ... ]
+```
+
+---
+
+## 11. Observability
+
+Metrics (Prometheus, when `[metrics] enabled = true`):
+
+| Metric | Type | Labels | Notes |
+|---|---|---|---|
+| `otlp_requests_total` | counter | `view`, `signal`, `encoding`, `status` | One per request |
+| `otlp_decode_failures_total` | counter | `view`, `signal`, `reason` | `reason ∈ {protobuf, json, gzip, deflate, size_pre, size_post}` |
+| `otlp_partial_success_total` | counter | `view`, `signal` | One per request with `rejected > 0` |
+| `otlp_rejected_points_total` | counter | `view`, `signal` | Sum of `rejected` across requests |
+| `otlp_request_bytes` | histogram | `view`, `signal`, `encoding` | Pre-decompression body size |
+| `otlp_decoded_bytes` | histogram | `view`, `signal` | Post-decompression, pre-handler |
+| `otlp_dispatch_duration_ms` | histogram | `view`, `signal` | Handler execution time |
+
+Logs (per-app log file via `Rivers.log` / AppLogRouter):
+
+- INFO at request start with view, signal, encoding, size, trace_id.
+- WARN on partial success with rejected count and errorMessage.
+- ERROR on handler exception with stack trace.
+- ERROR on framework-level reject (415, 413, 400) with reason.
+
+Trace ID propagation: the framework generates a `trace_id` per request (existing pattern from `view_dispatch.rs:277`) and surfaces it on `ctx.trace_id`. Handlers can read it; the framework does **not** read `traceparent` from OTLP payloads (that's the customer's domain). Future enhancement (non-goal v1): respect inbound `traceparent` headers.
+
+---
+
+## 12. Examples
+
+### 12.1 Three signals, one handler module
+
+```toml
+[api.views.otel_ingest]
+path         = "otel"
+view_type    = "OTLP"
+auth         = "none"
+max_body_mb  = 4
+
+[api.views.otel_ingest.handlers.metrics]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+resources  = ["cb_db"]
+
+[api.views.otel_ingest.handlers.logs]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestLogs"
+resources  = ["cb_db"]
+
+[api.views.otel_ingest.handlers.traces]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestTraces"
+resources  = ["cb_db"]
+```
+
+```typescript
+// libraries/handlers/otel.ts
+import { Ctx } from './_lib.ts';
+
+export async function ingestMetrics(ctx: Ctx): Promise<void> {
+    const payload = ctx.otel.payload;
+    let rejected = 0;
+    let reason = '';
+    for (const rm of payload.resourceMetrics ?? []) {
+        for (const sm of rm.scopeMetrics ?? []) {
+            for (const m of sm.metrics ?? []) {
+                try {
+                    await Rivers.db.cb_db.run(
+                        'INSERT INTO telemetry_events (name, payload) VALUES ($1, $2)',
+                        [m.name, JSON.stringify(m)]
+                    );
+                } catch (e) {
+                    rejected += 1;
+                    reason = (e as Error).message;
+                }
+            }
+        }
+    }
+    if (rejected > 0) {
+        ctx.otel.rejected = rejected;
+        ctx.otel.errorMessage = reason;
+    }
+}
+
+export async function ingestLogs(ctx: Ctx): Promise<void> { /* ... */ }
+export async function ingestTraces(ctx: Ctx): Promise<void> { /* ... */ }
+```
+
+### 12.2 Single handler with discriminator
+
+```toml
+[api.views.otel_ingest]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.otel_ingest.handler]
+type       = "codecomponent"
+language   = "typescript"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestAny"
+resources  = ["cb_db"]
+```
+
+```typescript
+export async function ingestAny(ctx: Ctx): Promise<void> {
+    switch (ctx.otel.kind) {
+        case 'metrics': /* ... */ break;
+        case 'logs':    /* ... */ break;
+        case 'traces':  /* ... */ break;
+    }
+}
+```
+
+### 12.3 Metrics-only ingest (other signals 404)
+
+```toml
+[api.views.metrics_only]
+path      = "otel"
+view_type = "OTLP"
+
+[api.views.metrics_only.handlers.metrics]
+type       = "codecomponent"
+module     = "libraries/handlers/otel.ts"
+entrypoint = "ingestMetrics"
+resources  = ["cb_db"]
+```
+
+Requests to `/otel/v1/logs` and `/otel/v1/traces` return `404 {error: "OTLP signal '<x>' not configured on this view"}`.
+
+---
+
+## 13. Non-goals (v1)
+
+- **Protobuf response encoding.** Responses are always `application/json` in v1, regardless of inbound encoding. Real OTel clients accept JSON responses; protobuf-out can be added later if a client surfaces a need.
+- **OTLP/gRPC.** This spec covers OTLP/**HTTP** only. gRPC support would be a separate `view_type` and depends on Rivers landing a gRPC server primitive.
+- **Inbound `traceparent` correlation.** The framework generates its own `trace_id`; it does not parse W3C trace context from OTLP payloads or request headers in v1.
+- **Other compression algorithms.** Only `gzip` and `deflate`. `br` and `zstd` rejected with `415`.
+- **Schema validation of OTLP payload internals.** The framework decodes the envelope and hands `ctx.otel.payload` to the handler. Field-level validation (e.g., enforcing that every span has a `traceId`) is the handler's job.
+- **Resource attribute extraction.** No automatic flattening of `resource.attributes` onto `ctx`. Handlers walk the envelope.
+- **Rate limiting per OTLP client.** Standard per-view `rate_limit_per_minute` (IP-based) is available; per-bearer-token rate limiting is out of scope for v1.
+
+---
+
+## 14. Implementation Notes
+
+### 14.1 Code reuse
+
+| Existing piece | Reuse |
+|---|---|
+| `crates/riversd/src/otlp_transcoder.rs` | Used as-is for protobuf → JSON |
+| `crates/riversd/src/server/view_dispatch.rs` `match view_type` switch | Add `"OTLP" => execute_otlp_view(...)` branch |
+| REST codecomponent dispatch path | OTLP handlers go through the same `process_pool` dispatch with `TaskKind::Rest` (or a new `TaskKind::Otlp` if discriminator-level metrics are wanted) |
+| Per-app log routing, metrics fabric, rate limiter | All reused unchanged |
+| `validate_structural` pipeline | Add `validate_otlp_view` step emitting X-OTLP-N codes |
+
+### 14.2 New code surface
+
+| New piece | Estimated size | Notes |
+|---|---|---|
+| `crates/riversd/src/server/otlp_view.rs` | ~200 lines | Body extraction, decompression, transcode, dispatch, response wrap |
+| `crates/rivers-runtime/src/bundle_loader/validate_otlp.rs` | ~120 lines | X-OTLP-1..8, W-OTLP-1..2 |
+| `OtelContext` shape in handler envelope (`engine-sdk` SerializedTaskContext) | ~30 lines | New `otel` field on the dispatch envelope, optional |
+| `flate2` dependency | already present transitively via tonic; verify | If not present, add to `riversd` crate's Cargo.toml |
+| Bundle-validation amendments doc entry | ~10 lines | Document the new X-OTLP-N codes |
+| Feature inventory entry (§2.6c or new §2.6) | ~10 lines | Link to this spec |
+
+### 14.3 Sequencing relative to current sprint
+
+This is **not** on the current sprint per [project_sprint_cb_unblock](file:///Users/pcastone/.claude/projects/-Users-pcastone-Projects-rust-rivers-pub/memory/project_sprint_cb_unblock.md) (probe migration + validator hardening + cron view). Suggested sequencing for the next sprint:
+
+1. Land the validator (`validate_otlp_view`) and feature-inventory stub behind a config flag — this alone surfaces the gap clearly in `riverpackage validate`.
+2. Land the dispatcher (`otlp_view.rs`) with multi-handler form. Protobuf path reuses P1.6; gzip is the only net-new wire-format work.
+3. Land the single-handler discriminator form.
+4. Wire `auth = "bearer"` once P1.12 lands.
+
+Each step is independently shippable. Step 1 alone closes the "Rivers gives no actionable error for OTLP misconfiguration" gap.

--- a/todo/changedecisionlog.md
+++ b/todo/changedecisionlog.md
@@ -6,6 +6,30 @@ readers.
 
 ---
 
+### CB-OTLP-D1 — 2026-05-11 — Track O1: OTLP errors use S005 + `[X-OTLP-N]` markers, not new per-rule codes
+
+**File affected:** `crates/rivers-runtime/src/validate_structural.rs`, `crates/rivers-runtime/src/validate_result.rs`
+**Spec reference:** `rivers-otlp-view-spec.md` §9; `rivers-bundle-validation-spec.md` §11.5.1
+**Decision:** All OTLP-view structural failures emit the existing `S005` error code with a `[X-OTLP-N]` marker prepended to the human-readable message, rather than introducing 6 new error codes (`O001`-`O006`). The warning case `W-OTLP-1` was given its own code (`W012`) because the existing warning catalog numbers each warning individually and there was no "generic warning code" to piggyback on.
+
+Rationale: the existing cron validator (`validate_cron_view`) uses the same pattern — every cron-specific rule emits `S005` with descriptive text. New per-rule codes would have to be registered in `validate_result::error_codes`, documented in `bundle-validation-spec §11`, and asserted in tests as separate strings — for no functional gain over `r.message.contains("[X-OTLP-N]")`. Markers stay searchable in docs and probes.
+
+**Resolution method:** Read `validate_cron_view` and surrounding tests; confirmed the project precedent during O1.1. CB's request bundle uses `X-OTLP-N` as documentation labels (not wire codes) anyway.
+
+---
+
+### CB-OTLP-D2 — 2026-05-11 — `auth = "bearer"` on OTLP views rejected; spec §8 to be amended
+
+**File affected:** `crates/rivers-runtime/src/validate_structural.rs` (`validate_otlp_view`), `docs/arch/rivers-otlp-view-spec.md` (§8 follow-up)
+**Spec reference:** `rivers-otlp-view-spec.md` §8 (to be amended); existing project resolution at `validate_structural.rs:126-130`
+**Decision:** The OTLP spec §8 calls for accepting `auth = "bearer"` with a runtime warning pending CB-P1.12. The validator code comments at `VALID_AUTH_MODES` (`validate_structural.rs:126-130`) make clear that P1.12 was *resolved* — not by adding `"bearer"` to the auth allowlist, but by routing bearer-style auth through `guard_view` (the per-view named-guard pattern). To stay consistent with that resolution: OTLP views accept only `auth = "none"` at structural validation; `auth = "bearer"` is rejected with an `[X-OTLP-3]` message that points the operator at `guard_view = "..."`.
+
+**Implication:** Spec §8 needs amendment to drop the "P1.12 pending" language and document the `guard_view` pattern as the way to do bearer auth on OTLP views. Captured as a follow-up in the changelog entry; deferred to spec-amendment commit.
+
+**Resolution method:** Read `VALID_AUTH_MODES` comment block during O1.1; cross-referenced `cb-rivers-feature-request.md` (claimed P1.12 still pending) against the actual code state.
+
+---
+
 ### Sprint 2026-05-09 — CB unblock plan (probe-derived)
 
 **CB-PROBE-D1 — Probe shape mismatch is a CB-side migration, not a Rivers code fix**

--- a/todo/changelog.md
+++ b/todo/changelog.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 2026-05-11 — CB-OTLP Track O1: validator-side acceptance of `view_type = "OTLP"`
+
+CB filed `cb-rivers-otlp-feature-request.zip` (2026-05-11) asking for a
+first-class OTLP/HTTP view type. Track O1 lands the **validator half** of
+that ask: `riverpackage validate` now accepts `view_type = "OTLP"` as a
+canonical value, walks the OTLP-view config, and rejects every shape the
+spec (`docs/arch/rivers-otlp-view-spec.md`) forbids with a marked
+`[X-OTLP-N]` S005 message. No dispatcher changes — the runtime still
+treats `OTLP` as unknown until O2 lands. Goal of O1 alone: when an
+operator writes a mis-configured OTLP view, `riverpackage validate` gives
+them an actionable error instead of a generic "unknown view type".
+
+| File | Change | Spec ref | Resolution |
+|------|--------|----------|------------|
+| `crates/rivers-runtime/src/validate_structural.rs` | Added `"OTLP"` to `VALID_VIEW_TYPES`. Added `"handlers"` + `"max_body_mb"` to `VIEW_FIELDS`. Extended the per-view-type `required` override to skip `path`/`method`/`handler` requirement for OTLP (it has its own handler shape). Added per-view dispatch branch for OTLP at the existing `view_type` switch — mirrors the Cron branch shape. Added new `validate_otlp_view` helper enforcing all X-OTLP-1..6 rules + `W-OTLP-1` warning. Also added "OTLP-only fields on non-OTLP views" rejection symmetric to the existing "Cron-only fields" guard. | `rivers-otlp-view-spec.md` §9 | New helper modeled on `validate_cron_view`. All structural errors emitted as `S005` with `[X-OTLP-N]` markers in the message for spec traceability — no new error codes were added except `W012` for the large-body warning. |
+| `crates/rivers-runtime/src/validate_result.rs` | Added `pub const W012: &str = "W012"` for the OTLP large-body warning. | spec §9 W-OTLP-1 | Existing W001-W011 numbering continued. |
+| `crates/rivers-runtime/src/validate_structural.rs` (tests) | 14 new unit tests in the existing `#[cfg(test)] mod tests` block. Covers multi-handler happy path, single-handler happy path, metrics-only form, X-OTLP-1 (all three signal suffixes), X-OTLP-2 (missing handler + unknown signal name), X-OTLP-3 (`auth=session` and `auth=bearer`), X-OTLP-4 (`streaming=true`), X-OTLP-5 (both handler forms), X-OTLP-6 (4 forbidden fields), W-OTLP-1 (max_body_mb=64), max_body_mb=0 hard fail, OTLP-only fields on Rest view, and a `view_type="OTL"` typo regression confirming the OTLP validator does NOT run on typo'd view types. All 14 green; full `cargo test -p rivers-runtime --lib` = 284/284 (was 270, +14). | spec §9 | `write_otlp_view` test helper added, mirrors `write_cron_view`. |
+| `docs/arch/rivers-feature-inventory.md` | New §2.6c — short feature-inventory entry pointing at the spec. | spec §1 | Mirrors §2.6b Cron entry. |
+| `docs/arch/rivers-bundle-validation-spec.md` | Added `OTLP` to the closed set of valid `view_type` values at §3. Filled in W005-W011 in the warnings catalog (previously stopped at W004 despite the runtime having W001-W011). Added W012 for `[W-OTLP-1]`. New §11.5.1 documenting the X-OTLP-N marker convention with a marker-to-rule table. | spec §9; validation spec §11 | Doc was already drift from runtime — opportunity-of-passing filled the W005-W011 gap. |
+
+**Scope:** Track O1 only. The dispatcher (Track O2), single-handler
+discriminator coverage tests (O3), bearer auth (O4 — deferred to P1.12),
+and observability/tutorial/version-bump (O5) are tracked in `todo/tasks.md`
+under "Sprint 2026-05-XX — `view_type = "OTLP"`".
+
+**Spec correction surfaced during O1.1:**
+`rivers-otlp-view-spec.md` §8 assumed CB-P1.12 (`auth = "bearer"`) was
+pending. The validator-code comments at `validate_structural.rs:126-130`
+make clear P1.12 was *closed* by routing bearer-style auth through
+`guard_view` rather than adding `"bearer"` to `VALID_AUTH_MODES`. The
+validator therefore rejects `auth = "bearer"` on OTLP views with
+`[X-OTLP-3]` and a message pointing the operator at `guard_view`. The
+spec §8 needs amendment to reflect this — captured as a follow-up below.
+
+**Follow-up captured (not in this commit):**
+- `rivers-otlp-view-spec.md` §8 to be amended: replace "auth = bearer
+  gated on P1.12 pending" wording with the project's resolved pattern
+  (use `guard_view` for bearer-style auth on OTLP views). Drop W-OTLP-2
+  from §9.
+
 ## 2026-05-10 — Cron view: propagate handler `resources` as task capabilities (v0.61.1)
 
 CB filed `cb-rivers-cron-capability-bug` — a Cron view with

--- a/todo/tasks.md
+++ b/todo/tasks.md
@@ -2268,3 +2268,141 @@ direction" — synthetic-client built on polling infra):
 - CB can rerun their probe and see 0 unresolved EXPECTED FAIL.
 - Validator hardening prevents the next probe from silently passing.
 - Cron view spec, runtime, tests, docs, and CB-side adoption are all in.
+
+---
+
+## Sprint 2026-05-XX — `view_type = "OTLP"` (CB OTLP feature request)
+
+> **Source:** `cb-rivers-otlp-feature-request.zip` (filed 2026-05-11)
+> **Spec:** `docs/arch/rivers-otlp-view-spec.md`
+> **Goal:** ship a first-class OTLP/HTTP view type that handles JSON + protobuf + gzip/deflate, dispatches per-signal handlers, and emits OTLP partial-success responses.
+> **Lever:** P1.6 protobuf transcoder already exists at `crates/riversd/src/otlp_transcoder.rs` — most work is declarative plumbing, not parser work.
+> **Sequence:** Tracks are independently shippable. Track O1 (validator) alone gives operators an actionable error.
+
+**Confirmed from source (per Standard 1):**
+- P1.6 transcoder is wired at `crates/riversd/src/server/view_dispatch.rs:239-275` for protobuf decode → JSON re-encode on `/v1/{traces,metrics,logs}` paths.
+- View-type dispatch switch is at `view_dispatch.rs:196-209` (`match view_type` with arms for SSE, Websocket, Mcp; default falls through to REST).
+- Cron view validator emits S005 via `validate_structural::validate_cron_view` — same layer the OTLP validator hooks into.
+- No `flate2` direct dep in `crates/riversd/Cargo.toml` today — needs verification (may be transitive via tonic).
+
+**Inferred / to confirm:**
+- Whether to add a new `TaskKind::Otlp` variant or reuse `TaskKind::Rest` for OTLP handler dispatch — leaning reuse-Rest for v1, mark as decision-log entry in O5.3.
+- Where the `OtelContext` shape lives in `SerializedTaskContext` (`crates/rivers-engine-sdk`) — needs a code read before O2.
+
+---
+
+### Track O1 — Validator + feature-inventory stub
+
+**Files:** `crates/rivers-runtime/src/bundle_loader/validate_structural.rs` (or sibling), `crates/rivers-runtime/src/bundle_loader/validate_crossref.rs`, `docs/arch/rivers-feature-inventory.md`
+
+Goal: surfacing the gap in `riverpackage validate` even before the dispatcher lands. Operators trying to declare `view_type = "OTLP"` today get a generic "unknown view type" rather than an actionable error.
+
+- [x] **O1.1** — Read existing validators. **Findings (2026-05-11):**
+  - Cron analogue: `crates/rivers-runtime/src/validate_structural.rs:996-1171` (`fn validate_cron_view`).
+  - Dispatch site: `validate_structural.rs:805-828` — branches on `view_type == "Cron"`.
+  - Constants to edit: `VALID_VIEW_TYPES` (line 119-121, add `"OTLP"`), `VIEW_FIELDS` (line 97-111, add `"handlers"` + `"max_body_mb"`), `VIEW_REQUIRED` override (line 798, add OTLP branch — same shape as Cron, skip path/method req).
+  - Error-code convention: **single `S005`** for all structural issues with descriptive messages. Spec's `X-OTLP-N` codes are documentation labels, NOT runtime codes — embed `[X-OTLP-N]` markers in S005 messages for traceability. Same pattern Cron uses.
+  - Test helpers: `create_valid_bundle(dir)` at line 1443 and `write_cron_view(dir, body)` at line 2447 — pattern to mirror with `write_otlp_view`.
+  - **Spec correction surfaced:** `VALID_AUTH_MODES = ["none", "session"]` (line 131). The comment at line 126-130 says CB-P1.12 was *resolved* (not pending) by using `guard_view` instead of `auth = "bearer"`. The OTLP spec §8 assumed P1.12 was pending and would add `"bearer"`. **Adjustment:** OTLP views accept only `auth = "none"` (X-OTLP-3 rejects anything else, including `"session"` and `"bearer"`). Drop W-OTLP-2 entirely. Bearer-style auth on OTLP views is achieved via `guard_view` per project convention. Spec amendment goes in §14 changelog.
+  - **O1.3 scope adjustment:** X-OTLP-7/8 (module exists, entrypoint exported) require the `handlers.*` field to be parsed into `ApiViewConfig` — which is O2 work. Layer 1 can only verify the value is a string at TOML level. **Defer O1.3 to land with O2** (when there's a parsed `handlers` field for `validate_crossref` to walk). Marked accordingly below.
+- [x] **O1.2** — `validate_otlp_view` added to `validate_structural.rs:1200-1422`. Emits all S005 errors with `[X-OTLP-N]` markers in the message (decision CB-OTLP-D1); W-OTLP-1 emitted as new `W012` code. Per CB-OTLP-D2: `auth = "bearer"` rejected with `[X-OTLP-3]` (P1.12 was resolved via `guard_view`, not by accepting bearer in `VALID_AUTH_MODES`). W-OTLP-2 dropped entirely.
+  - **Validated:** 14 unit tests added (3 happy paths + 11 negative); `cargo test -p rivers-runtime --lib` = **284/284 green** (was 270). Includes `typo_otl_still_produces_unknown_view_type_error` which subsumes O1.4's regression test.
+- [!] **O1.3 (DEFERRED to O2 sprint)** — Cross-ref validation hook for X-OTLP-7/8. Blocked: requires `handlers: HashMap<String, HandlerConfig>` to land on `ApiViewConfig` first (an O2 data-model change). At Layer 1 today, all we can do is assert each handler's `module` field is a string — which is generic S004 territory, not OTLP-specific. Will reopen when O2 lands the parsed `handlers` field.
+- [x] **O1.4** — Done as part of O1.2. Dispatch wired at `validate_structural.rs:812-817` (`else if view_type == "OTLP"` branch). Typo regression test `typo_otl_still_produces_unknown_view_type_error` asserts the generic unknown-view-type S005 fires on `view_type = "OTL"` and that no `[X-OTLP-*]` markers appear (proving the OTLP validator does NOT run).
+- [x] **O1.5** — §2.6c entry added to `docs/arch/rivers-feature-inventory.md` between §2.6b (Cron) and §2.7 (Streaming REST). 9 bullets covering content-type negotiation, gzip, path mounting, both handler forms, partial-success response, X-OTLP-N codes, and the Track O1/O2 staging.
+- [x] **O1.6** — Validator code registry updated in `docs/arch/rivers-bundle-validation-spec.md`:
+  - `OTLP` added to the canonical `view_type` set at §3.
+  - W005-W011 backfilled in the §11.5 warnings catalog (existing doc drift — W001-W011 were in code but doc stopped at W004).
+  - W012 added for `[W-OTLP-1]`.
+  - New §11.5.1 documents the `[X-OTLP-N]` marker-on-S005 convention with a table mapping each marker to its spec rule.
+  - X-OTLP-7/8 (Layer 3) explicitly noted as deferred to O2 (see §14.3 of the OTLP spec).
+
+**Track O1 exit:** `riverpackage validate` on a mis-declared OTLP view emits an actionable X-OTLP-N error. No runtime behavior changes yet.
+
+---
+
+### Track O2 — Dispatcher (multi-handler form)
+
+**Files:** `crates/riversd/src/server/otlp_view.rs` (new), `crates/riversd/src/server/view_dispatch.rs`, `crates/riversd/src/lib.rs` (module declaration), `crates/riversd/Cargo.toml` (`flate2` dep if not transitive)
+
+- [ ] **O2.1** — Verify `flate2` availability. `cargo tree -p riversd | grep flate2` and/or check `Cargo.lock`. If absent, add `flate2 = "1"` to `riversd`'s dependencies.
+  - **Validate:** `cargo build -p riversd` green; binary size delta logged in task entry.
+- [ ] **O2.2** — Read `rivers-engine-sdk` `SerializedTaskContext` to locate where to plumb the new `otel` field on the dispatch envelope. Decide: extend `SerializedTaskContext` with an optional `otel: Option<OtelContext>` field, OR pass via a side channel. Default to extending — matches how `request` is plumbed today.
+  - **Validate:** decision recorded in this task entry; file paths + struct names listed.
+- [ ] **O2.3** — Define `OtelContext` shape in engine-sdk (or wherever O2.2 lands it): `{ kind: String, payload: serde_json::Value, encoding: String }`. Implement `Serialize` + `Deserialize`.
+  - **Validate:** 1 unit test round-trips JSON.
+- [ ] **O2.4** — New file `crates/riversd/src/server/otlp_view.rs` skeleton. Public entry: `pub async fn execute_otlp_view(ctx: AppContext, request: Request, matched: MatchedRoute) -> Response`. Wire into `view_dispatch.rs:196` match as `"OTLP" => execute_otlp_view(...).await`.
+  - **Validate:** `cargo build -p riversd` green; route matches but returns 501-not-yet-implemented placeholder when hit.
+- [ ] **O2.5** — Inside `execute_otlp_view`: implement size pre-check against `max_body_mb` (default 4). Return `413` with `{error: "..."}` if exceeded.
+  - **Validate:** unit test calls `execute_otlp_view` with a 5MB body under default config → 413.
+- [ ] **O2.6** — Implement decompression: gzip/deflate via `flate2::read::GzDecoder` / `flate2::read::DeflateDecoder`. Bounded read up to `max_body_mb * 1.5`. Return `415` for unknown `Content-Encoding`, `413` for post-decompression overrun.
+  - **Validate:** unit tests for gzip happy path, deflate happy path, unknown encoding `br` → 415, zip-bomb (1KB gzipped → 100MB inflated) → 413.
+- [ ] **O2.7** — Implement Content-Type negotiation. `application/json` → `serde_json::from_slice`; `application/x-protobuf` → call existing `crate::otlp_transcoder::transcode_otlp_protobuf` and parse the returned JSON bytes. Other → 415. Map transcoder errors:
+  - `UnknownSignal` → `404` (caller declared OTLP view but path isn't /v1/{metrics,logs,traces})
+  - `DecodeFailed` → `415` with the existing CB-observed error body shape
+  - **Validate:** unit tests for JSON happy, protobuf happy (use a small captured `ExportMetricsServiceRequest` test fixture), malformed JSON → 400, malformed protobuf → 415.
+- [ ] **O2.8** — Implement path routing. Extract the trailing segment (`metrics` | `logs` | `traces`) from `request.uri().path()`. Match against the view's declared `handlers.*` — if present, dispatch; if absent and a single `handler` is declared, dispatch to that with `ctx.otel.kind` set; otherwise 404.
+  - **Validate:** unit tests for metrics-only view returning 404 on /v1/logs; all-three view dispatching to correct handler.
+- [ ] **O2.9** — Build `OtelContext` and the full dispatch envelope. Call `process_pool::dispatch_codecomponent` (or whatever the canonical entry is — confirm by reading the REST dispatch path) with the OTLP handler's config. Reuse `TaskKind::Rest` for v1 (decision per the source preamble).
+  - **Validate:** 1 integration test boots a bundle with an OTLP view + a stub TS handler that echoes `ctx.otel.kind`, POSTs JSON, asserts handler ran and saw correct kind.
+- [ ] **O2.10** — Implement response wrapping. After handler returns, read `ctx.otel.rejected` and `ctx.otel.errorMessage` from the result envelope. Emit:
+  - `200 {}` when rejected == 0 or absent
+  - `200 {partialSuccess: {<rejected-field>: N, errorMessage: "..."}}` when rejected > 0, where `<rejected-field>` ∈ {rejectedDataPoints, rejectedLogRecords, rejectedSpans} selected from `ctx.otel.kind`
+  - `500 {error: "..."}` on handler exception
+  - **Validate:** unit tests for each branch; the partialSuccess field name selection.
+- [ ] **O2.11** — Wire per-app log routing + trace_id generation. Reuse the existing `uuid::Uuid::new_v4()` pattern from `view_dispatch.rs:277`. INFO log at request start; WARN on partial success; ERROR on framework reject or handler exception.
+  - **Validate:** integration test asserts `log/apps/<app>.log` contains expected INFO+WARN entries after a partial-success request.
+
+**Track O2 exit:** end-to-end JSON + protobuf + gzip OTLP ingest works. CB's run-probe.sh passes all 3 tests against this build.
+
+---
+
+### Track O3 — Single-handler discriminator form
+
+Validator already handles this in O1.2/O1.4 (X-OTLP-5). Dispatcher already handles it in O2.8. This track is purely about tests + tutorial coverage.
+
+- [ ] **O3.1** — Integration test: bundle with single `handler` and `ctx.otel.kind` switch. POST to each of `/v1/{metrics,logs,traces}` and assert the same handler ran with the right `kind`.
+  - **Validate:** test green.
+- [ ] **O3.2** — Negative test: bundle with both `handler` and `handlers.metrics` declared fails preflight with X-OTLP-5. (Already covered by O1.2 but assert via `riverpackage validate` CLI as well.)
+  - **Validate:** CLI exit code non-zero, stderr contains "X-OTLP-5".
+
+---
+
+### Track O4 — Auth (deferred — gated on P1.12)
+
+- [ ] **O4.1 (DEFERRED — P1.12 dependency)** — Wire `auth = "bearer"` resolution before handler dispatch. Reuse the P1.12 bearer pipeline (entry point TBD when P1.12 lands). Populate `ctx.session` on success; return 401 with the existing error shape on failure.
+- [ ] **O4.2 (DEFERRED)** — Flip W-OTLP-2 off in O1.2 once P1.12 lands. Update spec §8 to remove the "pending" caveat.
+
+---
+
+### Track O5 — Observability, docs, version bump
+
+- [ ] **O5.1** — Metrics: add the 7 metrics from spec §11 to the existing `metrics` module. Wire emission points into the dispatcher. Names: `otlp_requests_total`, `otlp_decode_failures_total`, `otlp_partial_success_total`, `otlp_rejected_points_total`, `otlp_request_bytes`, `otlp_decoded_bytes`, `otlp_dispatch_duration_ms`.
+  - **Validate:** scrape `/metrics` after a handful of OTLP requests; all 7 metrics present with labels.
+- [ ] **O5.2** — Tutorial: `docs/guide/tutorials/tutorial-otlp.md` mirroring the cron tutorial shape. Cover: when to use, multi-handler form, single-handler form, content-type/compression behavior, partial-success response, observability.
+  - **Validate:** tutorial renders; commands match working bundle.
+- [ ] **O5.3** — Decision-log entry CB-OTLP-D1 in `todo/changedecisionlog.md`: TaskKind reuse vs new variant, why JSON-only response in v1, why path-tail dispatch over per-signal `path` declarations.
+  - **Validate:** entry committed.
+- [ ] **O5.4** — Changelog entry in `todo/changelog.md` summarizing the sprint.
+  - **Validate:** entry committed.
+- [ ] **O5.5** — Version bump. `view_type = "OTLP"` is a genuinely new conceptual capability → `just bump-minor`.
+  - **Validate:** workspace `Cargo.toml` reflects the new minor; `cargo build` green at new version.
+- [ ] **O5.6** — Run CB's `run-probe.sh` end-to-end against the bumped build. Test 1 (JSON), Test 2 (protobuf), Test 3 (gzip) should all PASS. Capture output, attach to changelog entry.
+  - **Validate:** all 3 tests PASS; output captured.
+
+---
+
+### Track O6 — Cross-cutting
+
+- [ ] **O6.1** — `git commit` per track (O1 = patch-bump-OK; O2 = minor-bump; O3-O5 = build-only bumps if no additional public-API change). Split into multiple PRs if the diff gets unwieldy — spec PR (already in flight) + O1 PR + O2 PR + O3+O5 PR is a reasonable shape.
+- [ ] **O6.2** — Update `MEMORY.md` sprint pointer to point at this sprint once it closes.
+- [ ] **O6.3** — Notify CB team via the existing rivers-upstream channel that the feature has landed; point them at the spec + tutorial.
+
+---
+
+**Sprint exit criteria (gap analysis per Standard 9):**
+- `riverpackage validate` rejects mis-declared OTLP views with actionable X-OTLP-N errors.
+- CB's `run-probe.sh` Test 1 (JSON), Test 2 (protobuf), Test 3 (gzip) all PASS.
+- Multi-handler form, single-handler form, and metrics-only form all work end-to-end.
+- Spec, feature inventory, tutorial, decision log, and changelog all updated.
+- `auth = "bearer"` track explicitly deferred to P1.12 sprint (not blocking this sprint's close).


### PR DESCRIPTION
## Summary

- New `view_type = "OTLP"` spec at `docs/arch/rivers-otlp-view-spec.md` + structural validator that accepts the type, walks the OTLP config, and rejects mis-declarations with marked `[X-OTLP-N]` S005 messages.
- **Validator-only** — no dispatcher, no runtime behavior change. CB's `riverpackage validate` now gives actionable errors for OTLP misconfig instead of "unknown view type". Track O2 (dispatcher) is tracked in `todo/tasks.md` and pending a planning re-pass.
- 14 new unit tests; rivers-runtime `--lib` goes 270 → 284 green.

Two design decisions captured in `todo/changedecisionlog.md`:

- **CB-OTLP-D1** — OTLP rules emit existing `S005` with `[X-OTLP-N]` markers in the message rather than per-rule error codes. Matches the cron-view precedent. Exception: `W012` for the `max_body_mb > 16` warning, which follows the warning-catalog convention.
- **CB-OTLP-D2** — `auth = "bearer"` on OTLP views rejected with `[X-OTLP-3]`. The OTLP spec assumed CB-P1.12 (`auth = "bearer"`) was pending; reading the existing `VALID_AUTH_MODES` comments at `validate_structural.rs:126-130` made clear P1.12 was *resolved* by routing bearer through `guard_view`. The spec §8 needs a follow-up amendment to drop the "P1.12 pending" wording — captured in the changelog.

## Versioning

`just bump` only (build stamp `+0139110526` → `+1721110526`). Validator + docs change, no shipped runtime behavior change.

## Test plan

- [x] `cargo test -p rivers-runtime --lib` — 284/284 green (was 270, +14 OTLP tests)
- [x] `cargo build -p riverpackage` clean
- [x] Smoke: `riverpackage validate` against a hand-crafted broken OTLP bundle emits 4 distinct `[X-OTLP-N]` errors (1, 2, 3, 4) — see commit message

## Out of scope (deferred)

- **Track O2** — dispatcher (`otlp_view.rs`), engine-sdk `OtelContext` plumbing, V8 binding for `ctx.otel`, integration tests. Needs a planning re-pass because the original task list undercounted the engine-sdk/V8 work.
- **Track O4** — `auth = "bearer"` runtime; CB-OTLP-D2 explains the resolution (use `guard_view`).
- **OTLP spec §8 amendment** — drop "P1.12 pending" wording (follow-up commit on the next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)